### PR TITLE
[FIX] Card, Screenshot 테이블의 index 필드명 변경

### DIFF
--- a/src/main/java/site/katchup/katchupserver/api/card/domain/Card.java
+++ b/src/main/java/site/katchup/katchupserver/api/card/domain/Card.java
@@ -29,7 +29,7 @@ public class Card extends BaseEntity {
     private Long id;
 
     @Column(nullable = false)
-    private Long index;
+    private Long placement_order;
 
     @Column(length = 2000)
     private String content;
@@ -57,8 +57,8 @@ public class Card extends BaseEntity {
     private List<Link> links = new ArrayList<>();
 
     @Builder
-    public Card(Long index, String content, String note, boolean isDeleted, LocalDateTime deletedAt, Task task) {
-        this.index = index;
+    public Card(Long placement_order, String content, String note, boolean isDeleted, LocalDateTime deletedAt, Task task) {
+        this.placement_order = placement_order;
         this.content = content;
         this.note = note;
         this.isDeleted = isDeleted;

--- a/src/main/java/site/katchup/katchupserver/api/screenshot/domain/Screenshot.java
+++ b/src/main/java/site/katchup/katchupserver/api/screenshot/domain/Screenshot.java
@@ -21,7 +21,7 @@ public class Screenshot extends BaseEntity {
     private UUID id;
 
     @Column(nullable = false)
-    private int index;
+    private int tag_order;
 
     @Column(nullable = false)
     private String url;
@@ -31,9 +31,9 @@ public class Screenshot extends BaseEntity {
     private Card card;
 
     @Builder
-    public Screenshot(int index, String url, Card card) {
+    public Screenshot(int tag_order, String url, Card card) {
         this.id = randomUUID();
-        this.index = index;
+        this.tag_order = tag_order;
         this.url = url;
         this.card = card;
         this.card.addScreenshot(this);

--- a/src/test/java/site/katchup/katchupserver/api/card/domain/CardTest.java
+++ b/src/test/java/site/katchup/katchupserver/api/card/domain/CardTest.java
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import site.katchup.katchupserver.api.category.domain.Category;
-import site.katchup.katchupserver.api.folder.domain.Folder;
+import site.katchup.katchupserver.api.category.domain.domain.Folder;
 import site.katchup.katchupserver.api.card.repository.CardRepository;
 import site.katchup.katchupserver.api.task.domain.Task;
 import site.katchup.katchupserver.api.task.repository.TaskRepository;
@@ -34,7 +34,7 @@ public class CardTest {
         taskRepository.save(task);
 
         Card card = Card.builder()
-                .index(1L)
+                .placement_order(1L)
                 .content("Test Content")
                 .note("Test Note")
                 .isDeleted(false)
@@ -47,7 +47,7 @@ public class CardTest {
 
         // then
         Card savedCard = cardRepository.findById(card.getId()).orElseThrow();
-        assertThat(savedCard.getIndex()).isEqualTo(1L);
+        assertThat(savedCard.getPlacement_order()).isEqualTo(1L);
         assertThat(savedCard.getContent()).isEqualTo("Test Content");
         assertThat(savedCard.getNote()).isEqualTo("Test Note");
         assertThat(savedCard.isDeleted()).isFalse();

--- a/src/test/java/site/katchup/katchupserver/api/card/domain/CardTest.java
+++ b/src/test/java/site/katchup/katchupserver/api/card/domain/CardTest.java
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import site.katchup.katchupserver.api.category.domain.Category;
-import site.katchup.katchupserver.api.category.domain.domain.Folder;
+import site.katchup.katchupserver.api.folder.domain.Folder;
 import site.katchup.katchupserver.api.card.repository.CardRepository;
 import site.katchup.katchupserver.api.task.domain.Task;
 import site.katchup.katchupserver.api.task.repository.TaskRepository;

--- a/src/test/java/site/katchup/katchupserver/api/screenshot/domain/ScreenshotTest.java
+++ b/src/test/java/site/katchup/katchupserver/api/screenshot/domain/ScreenshotTest.java
@@ -7,7 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import site.katchup.katchupserver.api.card.domain.Card;
 import site.katchup.katchupserver.api.category.domain.Category;
-import site.katchup.katchupserver.api.category.domain.domain.Folder;
+import site.katchup.katchupserver.api.folder.domain.Folder;
 import site.katchup.katchupserver.api.screenshot.repository.ScreenshotRepository;
 import site.katchup.katchupserver.api.task.domain.Task;
 

--- a/src/test/java/site/katchup/katchupserver/api/screenshot/domain/ScreenshotTest.java
+++ b/src/test/java/site/katchup/katchupserver/api/screenshot/domain/ScreenshotTest.java
@@ -7,7 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import site.katchup.katchupserver.api.card.domain.Card;
 import site.katchup.katchupserver.api.category.domain.Category;
-import site.katchup.katchupserver.api.folder.domain.Folder;
+import site.katchup.katchupserver.api.category.domain.domain.Folder;
 import site.katchup.katchupserver.api.screenshot.repository.ScreenshotRepository;
 import site.katchup.katchupserver.api.task.domain.Task;
 
@@ -26,10 +26,10 @@ class ScreenshotTest {
         Category category = Category.builder().name("Test Category").build();
         Folder folder = Folder.builder().category(category).name("Test Folder").build();
         Task task = Task.builder().folder(folder).name("Test Task").build();
-        Card card = Card.builder().index(1L).isDeleted(false).task(task).build();
+        Card card = Card.builder().placement_order(1L).isDeleted(false).task(task).build();
 
         Screenshot screenshot = Screenshot.builder()
-                .index(1)
+                .tag_order(1)
                 .url("https://example.com/katchup_screenshot.png")
                 .card(card)
                 .build();
@@ -41,7 +41,7 @@ class ScreenshotTest {
         Assertions.assertNotNull(savedScreenshot.getId());
         Assertions.assertTrue(isValidUUID(savedScreenshot.getId().toString()));
         Assertions.assertEquals(savedScreenshot.getId().toString(), screenshot.getId().toString());
-        Assertions.assertEquals(savedScreenshot.getIndex(), screenshot.getIndex());
+        Assertions.assertEquals(savedScreenshot.getTag_order(), screenshot.getTag_order());
         Assertions.assertEquals(savedScreenshot.getUrl(), screenshot.getUrl());
         Assertions.assertEquals(savedScreenshot.getCard().getId(), screenshot.getCard().getId());
     }


### PR DESCRIPTION
## 📝 Summary
Card, Screenshot 테이블의 index 필드명 변경을 변경하였습니다.


## 👩‍💻 Contents
Card 테이블의 index -> placment_order
Screenshot 테이블의 index -> tag_order


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #13 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
