### PR TITLE
#22 [FEAT] 대분류 카테고리 전체 목록 조회 API

### DIFF
--- a/src/main/java/site/katchup/katchupserver/api/category/controller/CategoryController.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/controller/CategoryController.java
@@ -1,0 +1,37 @@
+package site.katchup.katchupserver.api.category.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import site.katchup.katchupserver.api.category.domain.Category;
+import site.katchup.katchupserver.api.category.dto.response.CategoryResponseDto;
+import site.katchup.katchupserver.api.category.service.CategoryService;
+import site.katchup.katchupserver.common.dto.ApiResponseDto;
+import site.katchup.katchupserver.common.response.SuccessStatus;
+import site.katchup.katchupserver.config.jwt.JwtTokenProvider;
+
+import java.util.List;
+import java.util.Optional;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@RestController
+@RequiredArgsConstructor(access = PRIVATE)
+@RequestMapping("/api/v1/categories")
+public class CategoryController {
+
+    private final CategoryService categoryService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @GetMapping()
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<List<CategoryResponseDto>> getAllCategory(HttpServletRequest request) {
+        String accessToken = jwtTokenProvider.resolveToken(request);
+        Long memberId = jwtTokenProvider.getAccessTokenPayload(accessToken);
+
+        return ApiResponseDto.success(SuccessStatus.READ_ALL_CATEGORY_SUCCESS, categoryService.getAllCategory(memberId));
+    }
+
+}

--- a/src/main/java/site/katchup/katchupserver/api/category/controller/CategoryController.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/controller/CategoryController.java
@@ -1,7 +1,5 @@
 package site.katchup.katchupserver.api.category.controller;
 
-import jakarta.servlet.http.HttpServletRequest;
-import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -10,7 +8,6 @@ import site.katchup.katchupserver.api.category.service.CategoryService;
 import site.katchup.katchupserver.api.member.domain.Member;
 import site.katchup.katchupserver.common.dto.ApiResponseDto;
 import site.katchup.katchupserver.common.response.SuccessStatus;
-import site.katchup.katchupserver.config.jwt.JwtTokenProvider;
 
 import java.security.Principal;
 import java.util.List;

--- a/src/main/java/site/katchup/katchupserver/api/category/controller/CategoryController.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/controller/CategoryController.java
@@ -5,15 +5,15 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
-import site.katchup.katchupserver.api.category.domain.Category;
 import site.katchup.katchupserver.api.category.dto.response.CategoryResponseDto;
 import site.katchup.katchupserver.api.category.service.CategoryService;
+import site.katchup.katchupserver.api.member.domain.Member;
 import site.katchup.katchupserver.common.dto.ApiResponseDto;
 import site.katchup.katchupserver.common.response.SuccessStatus;
 import site.katchup.katchupserver.config.jwt.JwtTokenProvider;
 
+import java.security.Principal;
 import java.util.List;
-import java.util.Optional;
 
 import static lombok.AccessLevel.PRIVATE;
 
@@ -23,13 +23,11 @@ import static lombok.AccessLevel.PRIVATE;
 public class CategoryController {
 
     private final CategoryService categoryService;
-    private final JwtTokenProvider jwtTokenProvider;
 
     @GetMapping()
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponseDto<List<CategoryResponseDto>> getAllCategory(HttpServletRequest request) {
-        String accessToken = jwtTokenProvider.resolveToken(request);
-        Long memberId = jwtTokenProvider.getAccessTokenPayload(accessToken);
+    public ApiResponseDto<List<CategoryResponseDto>> getAllCategory(Principal principal) {
+        Long memberId = Member.getMemberId(principal);
 
         return ApiResponseDto.success(SuccessStatus.READ_ALL_CATEGORY_SUCCESS, categoryService.getAllCategory(memberId));
     }

--- a/src/main/java/site/katchup/katchupserver/api/category/dto/response/CategoryResponseDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/dto/response/CategoryResponseDto.java
@@ -1,0 +1,22 @@
+package site.katchup.katchupserver.api.category.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@NoArgsConstructor(access = PRIVATE)
+@AllArgsConstructor
+public class CategoryResponseDto {
+
+    private Long categoryId;
+    private String name;
+    private boolean isShared;
+
+    public static CategoryResponseDto of(Long categoryId, String name, boolean isShared) {
+        return new CategoryResponseDto(categoryId, name, isShared);
+    }
+}

--- a/src/main/java/site/katchup/katchupserver/api/category/dto/response/CategoryResponseDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/dto/response/CategoryResponseDto.java
@@ -1,6 +1,5 @@
 package site.katchup.katchupserver.api.category.dto.response;
 
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/site/katchup/katchupserver/api/category/repository/CategoryRepository.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/repository/CategoryRepository.java
@@ -1,7 +1,9 @@
 package site.katchup.katchupserver.api.category.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import site.katchup.katchupserver.api.category.domain.Category;
+import site.katchup.katchupserver.api.member.domain.Member;
 
 import java.util.List;
 

--- a/src/main/java/site/katchup/katchupserver/api/category/repository/CategoryRepository.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/repository/CategoryRepository.java
@@ -1,0 +1,10 @@
+package site.katchup.katchupserver.api.category.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.katchup.katchupserver.api.category.domain.Category;
+
+import java.util.List;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+    List<Category> findByMemberId(Long memberId);
+}

--- a/src/main/java/site/katchup/katchupserver/api/category/repository/CategoryRepository.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/repository/CategoryRepository.java
@@ -1,9 +1,8 @@
 package site.katchup.katchupserver.api.category.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import site.katchup.katchupserver.api.category.domain.Category;
-import site.katchup.katchupserver.api.member.domain.Member;
+
 
 import java.util.List;
 

--- a/src/main/java/site/katchup/katchupserver/api/category/service/CategoryService.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/service/CategoryService.java
@@ -1,10 +1,6 @@
 package site.katchup.katchupserver.api.category.service;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import site.katchup.katchupserver.api.category.dto.response.CategoryResponseDto;
-import site.katchup.katchupserver.api.category.repository.CategoryRepository;
 
 import java.util.List;
 

--- a/src/main/java/site/katchup/katchupserver/api/category/service/CategoryService.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/service/CategoryService.java
@@ -1,0 +1,15 @@
+package site.katchup.katchupserver.api.category.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.katchup.katchupserver.api.category.dto.response.CategoryResponseDto;
+import site.katchup.katchupserver.api.category.repository.CategoryRepository;
+
+import java.util.List;
+
+public interface CategoryService {
+
+    //* 대분류 카테고리 전체 목록 조회
+    List<CategoryResponseDto> getAllCategory(Long memberId);
+}

--- a/src/main/java/site/katchup/katchupserver/api/category/service/Impl/CategoryServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/service/Impl/CategoryServiceImpl.java
@@ -1,20 +1,13 @@
 package site.katchup.katchupserver.api.category.service.Impl;
 
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import site.katchup.katchupserver.api.category.domain.Category;
 import site.katchup.katchupserver.api.category.dto.response.CategoryResponseDto;
 import site.katchup.katchupserver.api.category.repository.CategoryRepository;
 import site.katchup.katchupserver.api.category.service.CategoryService;
-import site.katchup.katchupserver.api.member.domain.Member;
-import site.katchup.katchupserver.api.member.repository.MemberRepository;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
-
-import static site.katchup.katchupserver.common.response.ErrorStatus.INVALID_MEMBER;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/site/katchup/katchupserver/api/category/service/Impl/CategoryServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/service/Impl/CategoryServiceImpl.java
@@ -1,0 +1,25 @@
+package site.katchup.katchupserver.api.category.service.Impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import site.katchup.katchupserver.api.category.domain.Category;
+import site.katchup.katchupserver.api.category.dto.response.CategoryResponseDto;
+import site.katchup.katchupserver.api.category.repository.CategoryRepository;
+import site.katchup.katchupserver.api.category.service.CategoryService;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryServiceImpl implements CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    @Override
+    public List<CategoryResponseDto> getAllCategory(Long memberId) {
+        return categoryRepository.findByMemberId(memberId).stream()
+                .map(category -> new CategoryResponseDto(category.getId(), category.getName(), category.isShared()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/site/katchup/katchupserver/api/category/service/Impl/CategoryServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/service/Impl/CategoryServiceImpl.java
@@ -1,14 +1,20 @@
 package site.katchup.katchupserver.api.category.service.Impl;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import site.katchup.katchupserver.api.category.domain.Category;
 import site.katchup.katchupserver.api.category.dto.response.CategoryResponseDto;
 import site.katchup.katchupserver.api.category.repository.CategoryRepository;
 import site.katchup.katchupserver.api.category.service.CategoryService;
+import site.katchup.katchupserver.api.member.domain.Member;
+import site.katchup.katchupserver.api.member.repository.MemberRepository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
+
+import static site.katchup.katchupserver.common.response.ErrorStatus.INVALID_MEMBER;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/site/katchup/katchupserver/api/member/domain/Member.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/domain/Member.java
@@ -5,8 +5,13 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.katchup.katchupserver.common.domain.BaseEntity;
+import site.katchup.katchupserver.common.exception.CustomException;
+import site.katchup.katchupserver.common.response.ErrorStatus;
+
+import java.security.Principal;
 
 import static jakarta.persistence.GenerationType.*;
+import static java.util.Objects.isNull;
 import static lombok.AccessLevel.*;
 
 @Entity
@@ -46,8 +51,14 @@ public class Member extends BaseEntity {
     }
 
     public void updateMemberStatus(boolean isNewUser, String refreshToken) {
-
         this.isNewUser = isNewUser;
         this.refreshToken = refreshToken;
+    }
+
+    public static Long getMemberId(Principal principal) {
+        if (isNull(principal)) {
+            throw new CustomException(ErrorStatus.INVALID_MEMBER);
+        }
+        return Long.valueOf(principal.getName());
     }
 }

--- a/src/main/java/site/katchup/katchupserver/common/response/ErrorStatus.java
+++ b/src/main/java/site/katchup/katchupserver/common/response/ErrorStatus.java
@@ -8,21 +8,25 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public enum ErrorStatus {
-    /*
-   BAD_REQUEST
-    */
+    /**
+     * 400 BAD_REQUEST
+     */
     VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     VALIDATION_REQUEST_MISSING_EXCEPTION(HttpStatus.BAD_REQUEST, "요청값이 입력되지 않았습니다."),
 
+    /**
+     * 401 UNAUTHORIZED
+     */
+    INVALID_MEMBER(HttpStatus.UNAUTHORIZED, "유효하지 않은 유저입니다."),
+    GOOGLE_UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "구글 로그인 실패. 만료되었거나 잘못된 구글 토큰입니다."),
 
-    /*
-    SERVER_ERROR
+    /**
+     * 500 SERVER_ERROR
      */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "예상치 못한 서버 에러가 발생했습니다."),
     BAD_GATEWAY_EXCEPTION(HttpStatus.BAD_GATEWAY, "일시적인 에러가 발생하였습니다.\n잠시 후 다시 시도해주세요!"),
-    SERVICE_UNAVAILABLE_EXCEPTION(HttpStatus.SERVICE_UNAVAILABLE, "현재 점검 중입니다.\n잠시 후 다시 시도해주세요!"),
-    INVALID_MEMBER(HttpStatus.UNAUTHORIZED, "유효하지 않은 유저입니다."),
-    GOOGLE_UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "구글 로그인 실패. 만료되었거나 잘못된 구글 토큰입니다.");
+    SERVICE_UNAVAILABLE_EXCEPTION(HttpStatus.SERVICE_UNAVAILABLE, "현재 점검 중입니다.\n잠시 후 다시 시도해주세요!")
+    ;
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/site/katchup/katchupserver/common/response/ErrorStatus.java
+++ b/src/main/java/site/katchup/katchupserver/common/response/ErrorStatus.java
@@ -18,6 +18,7 @@ public enum ErrorStatus {
      * 401 UNAUTHORIZED
      */
     UNAUTHORIZED_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    INVALID_MEMBER(HttpStatus.UNAUTHORIZED, "유효하지 않은 유저입니다."),
     GOOGLE_UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "구글 로그인 실패. 만료되었거나 잘못된 구글 토큰입니다."),
 
     /**

--- a/src/main/java/site/katchup/katchupserver/common/response/SuccessStatus.java
+++ b/src/main/java/site/katchup/katchupserver/common/response/SuccessStatus.java
@@ -20,7 +20,6 @@ public enum SuccessStatus {
      * category
      */
     READ_ALL_CATEGORY_SUCCESS(HttpStatus.OK, "대분류 카테고리 목록 조회 성공"),
-    ;
 
     /**
      *member

--- a/src/main/java/site/katchup/katchupserver/common/response/SuccessStatus.java
+++ b/src/main/java/site/katchup/katchupserver/common/response/SuccessStatus.java
@@ -10,11 +10,16 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public enum SuccessStatus {
 
-    /*
-    user
-    */
+    /**
+     * user
+     */
     SIGNUP_SUCCESS(HttpStatus.CREATED, "회원가입 성공"),
-    SIGNIN_SUCCESS(HttpStatus.OK, "로그인 성공")
+    SIGNIN_SUCCESS(HttpStatus.OK, "로그인 성공"),
+
+    /**
+     * category
+     */
+    READ_ALL_CATEGORY_SUCCESS(HttpStatus.OK, "대분류 카테고리 목록 조회 성공"),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
- 대분류 카테고리 전체 목록 조회 API 구현했습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- principal 객체를 통해서 멤버 id를 가져온 뒤, 해당 멤버의 category 데이터를 가져옵니다.

![image](https://github.com/Katchup-dev/Katchup-server/assets/68415644/8ea416ea-dfab-4136-9cc9-4b37bf71572f)

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #22 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
