### PR TITLE
[FEAT] 중분류 폴더 전체 목록 조회 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ ide
 
 resources/
 .jpb/
+
+.DS_Store

--- a/src/main/java/site/katchup/katchupserver/api/category/service/Impl/CategoryServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/service/Impl/CategoryServiceImpl.java
@@ -18,7 +18,7 @@ public class CategoryServiceImpl implements CategoryService {
     @Override
     public List<CategoryResponseDto> getAllCategory(Long memberId) {
         return categoryRepository.findByMemberId(memberId).stream()
-                .map(category -> new CategoryResponseDto(category.getId(), category.getName(), category.isShared()))
+                .map(category -> CategoryResponseDto.of(category.getId(), category.getName(), category.isShared()))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/site/katchup/katchupserver/api/folder/controller/FolderController.java
+++ b/src/main/java/site/katchup/katchupserver/api/folder/controller/FolderController.java
@@ -1,0 +1,34 @@
+package site.katchup.katchupserver.api.folder.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import site.katchup.katchupserver.api.folder.dto.response.FolderResponseDto;
+import site.katchup.katchupserver.api.folder.service.FolderService;
+import site.katchup.katchupserver.api.member.domain.Member;
+import site.katchup.katchupserver.common.dto.ApiResponseDto;
+import site.katchup.katchupserver.common.response.SuccessStatus;
+
+import java.security.Principal;
+import java.util.List;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@RestController
+@RequiredArgsConstructor(access = PRIVATE)
+@RequestMapping("/api/v1/folders")
+public class FolderController {
+
+    private final FolderService folderService;
+
+    @GetMapping()
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<List<FolderResponseDto>> getAllCategory(Principal principal) {
+        Long memberId = Member.getMemberId(principal);
+
+        return ApiResponseDto.success(SuccessStatus.READ_ALL_FOLDER_SUCCESS, folderService.getAllFolder(memberId));
+    }
+}

--- a/src/main/java/site/katchup/katchupserver/api/folder/dto/response/FolderResponseDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/folder/dto/response/FolderResponseDto.java
@@ -1,0 +1,20 @@
+package site.katchup.katchupserver.api.folder.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@NoArgsConstructor(access = PRIVATE)
+@AllArgsConstructor
+public class FolderResponseDto {
+
+    private Long id;
+    private String name;
+
+    public static FolderResponseDto of(Long id, String name) {
+        return new FolderResponseDto(id, name);
+    }
+}

--- a/src/main/java/site/katchup/katchupserver/api/folder/dto/response/FolderResponseDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/folder/dto/response/FolderResponseDto.java
@@ -11,10 +11,10 @@ import static lombok.AccessLevel.PRIVATE;
 @AllArgsConstructor
 public class FolderResponseDto {
 
-    private Long id;
+    private Long folderId;
     private String name;
 
-    public static FolderResponseDto of(Long id, String name) {
-        return new FolderResponseDto(id, name);
+    public static FolderResponseDto of(Long folderId, String name) {
+        return new FolderResponseDto(folderId, name);
     }
 }

--- a/src/main/java/site/katchup/katchupserver/api/folder/repository/FolderRepository.java
+++ b/src/main/java/site/katchup/katchupserver/api/folder/repository/FolderRepository.java
@@ -1,9 +1,10 @@
 package site.katchup.katchupserver.api.folder.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 import site.katchup.katchupserver.api.folder.domain.Folder;
 
-@Repository
+import java.util.List;
+
 public interface FolderRepository extends JpaRepository<Folder, Long> {
+    List<Folder> findByCategoryId(Long categoryId);
 }

--- a/src/main/java/site/katchup/katchupserver/api/folder/service/FolderService.java
+++ b/src/main/java/site/katchup/katchupserver/api/folder/service/FolderService.java
@@ -1,0 +1,11 @@
+package site.katchup.katchupserver.api.folder.service;
+
+import site.katchup.katchupserver.api.folder.dto.response.FolderResponseDto;
+
+import java.util.List;
+
+public interface FolderService {
+
+    //* 중분류 폴더 전체 목록 조회
+    List<FolderResponseDto> getAllFolder(Long memberId);
+}

--- a/src/main/java/site/katchup/katchupserver/api/folder/service/Impl/FolderServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/folder/service/Impl/FolderServiceImpl.java
@@ -1,0 +1,27 @@
+package site.katchup.katchupserver.api.folder.service.Impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import site.katchup.katchupserver.api.category.repository.CategoryRepository;
+import site.katchup.katchupserver.api.folder.dto.response.FolderResponseDto;
+import site.katchup.katchupserver.api.folder.repository.FolderRepository;
+import site.katchup.katchupserver.api.folder.service.FolderService;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class FolderServiceImpl implements FolderService {
+
+    private final FolderRepository folderRepository;
+    private final CategoryRepository categoryRepository;
+
+    @Override
+    public List<FolderResponseDto> getAllFolder(Long memberId) {
+        return categoryRepository.findByMemberId(memberId).stream()
+                .flatMap(category -> folderRepository.findByCategoryId(category.getId()).stream())
+                .map(folder -> FolderResponseDto.of(folder.getId(), folder.getName()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/site/katchup/katchupserver/common/dto/ApiResponseDto.java
+++ b/src/main/java/site/katchup/katchupserver/common/dto/ApiResponseDto.java
@@ -1,5 +1,6 @@
 package site.katchup.katchupserver.common.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,6 +11,7 @@ import site.katchup.katchupserver.common.response.SuccessStatus;
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApiResponseDto<T> {
 
     private final int status;

--- a/src/main/java/site/katchup/katchupserver/common/dto/ApiResponseDto.java
+++ b/src/main/java/site/katchup/katchupserver/common/dto/ApiResponseDto.java
@@ -12,20 +12,21 @@ import site.katchup.katchupserver.common.response.SuccessStatus;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ApiResponseDto<T> {
 
-    private final int code;
+    private final int status;
+    private final boolean success;
     private final String message;
     private T data;
 
     public static ApiResponseDto success(SuccessStatus successStatus) {
-        return new ApiResponseDto<>(successStatus.getHttpStatus().value(), successStatus.getMessage());
+        return new ApiResponseDto<>(successStatus.getHttpStatus().value(), true, successStatus.getMessage());
     }
 
     public static <T> ApiResponseDto<T> success(SuccessStatus successStatus, T data) {
-        return new ApiResponseDto<T>(successStatus.getHttpStatus().value(), successStatus.getMessage(), data);
+        return new ApiResponseDto<T>(successStatus.getHttpStatus().value(), true, successStatus.getMessage(), data);
     }
 
     public static ApiResponseDto error(ErrorStatus errorStatus) {
-        return new ApiResponseDto<>(errorStatus.getHttpStatus().value(), errorStatus.getMessage());
+        return new ApiResponseDto<>(errorStatus.getHttpStatus().value(), false, errorStatus.getMessage());
     }
 }
 

--- a/src/main/java/site/katchup/katchupserver/common/response/SuccessStatus.java
+++ b/src/main/java/site/katchup/katchupserver/common/response/SuccessStatus.java
@@ -22,6 +22,11 @@ public enum SuccessStatus {
     READ_ALL_CATEGORY_SUCCESS(HttpStatus.OK, "대분류 카테고리 목록 조회 성공"),
 
     /**
+     * folder
+     */
+    READ_ALL_FOLDER_SUCCESS(HttpStatus.OK, "중분류 폴더 전체 목록 조회 성공"),
+
+    /**
      *member
      */
     GET_MEMBER_SUCCESS(HttpStatus.OK, "프로필 팝업 조회 성공");


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
- 해당 유저의 중분류 폴더 전체 목록을 조회하는 API를 개발합니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- API 개발 : 해당 유저의 모든 대분류에 있는 중분류들을 전체 조회합니다.

- ApiResponseDto 수정 : json으로 내려주는 프로퍼티에서 명세서와 다른 부분 수정했습니다.
    - code -> status로 변경
    - success 값 추가
    - data가 null일 때, "data" : null이 아닌 data라는 프로퍼티를 아예 삭제할 수 있도록 했습니다.
 
<img width="896" alt="image" src="https://github.com/Katchup-dev/Katchup-server/assets/68415644/62a23995-6a8e-4cae-9b64-c9192d191812">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #23 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
