### PR TITLE
[FEAT] 업무 소분류 목록 조회

### DIFF
--- a/src/main/java/site/katchup/katchupserver/api/task/controller/TaskController.java
+++ b/src/main/java/site/katchup/katchupserver/api/task/controller/TaskController.java
@@ -1,0 +1,31 @@
+package site.katchup.katchupserver.api.task.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import site.katchup.katchupserver.api.member.domain.Member;
+import site.katchup.katchupserver.api.task.dto.TaskResponseDto;
+import site.katchup.katchupserver.api.task.service.TaskService;
+import site.katchup.katchupserver.common.dto.ApiResponseDto;
+import site.katchup.katchupserver.common.response.SuccessStatus;
+
+import java.security.Principal;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/tasks")
+@RequiredArgsConstructor
+public class TaskController {
+    private final TaskService taskService;
+
+    @GetMapping()
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<List<TaskResponseDto>> getAllTask(Principal principal) {
+        Long memberId = Member.getMemberId(principal);
+
+        return ApiResponseDto.success(SuccessStatus.GET_ALL_TASK_SUCCESS, taskService.getAllTask(memberId));
+    }
+}

--- a/src/main/java/site/katchup/katchupserver/api/task/dto/TaskResponseDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/task/dto/TaskResponseDto.java
@@ -1,0 +1,20 @@
+package site.katchup.katchupserver.api.task.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@NoArgsConstructor(access = PRIVATE)
+@AllArgsConstructor
+public class TaskResponseDto {
+    private Long taskId;
+
+    private String name;
+
+    public static TaskResponseDto of(Long taskId, String name) {
+        return new TaskResponseDto(taskId, name);
+    }
+}

--- a/src/main/java/site/katchup/katchupserver/api/task/repository/TaskRepository.java
+++ b/src/main/java/site/katchup/katchupserver/api/task/repository/TaskRepository.java
@@ -2,8 +2,12 @@ package site.katchup.katchupserver.api.task.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import site.katchup.katchupserver.api.category.domain.Category;
 import site.katchup.katchupserver.api.task.domain.Task;
+
+import java.util.List;
 
 @Repository
 public interface TaskRepository extends JpaRepository<Task, Long> {
+    List<Task> findByFolderId(Long folderId);
 }

--- a/src/main/java/site/katchup/katchupserver/api/task/service/Impl/TaskServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/task/service/Impl/TaskServiceImpl.java
@@ -1,0 +1,31 @@
+package site.katchup.katchupserver.api.task.service.Impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import site.katchup.katchupserver.api.category.repository.CategoryRepository;
+import site.katchup.katchupserver.api.folder.repository.FolderRepository;
+import site.katchup.katchupserver.api.task.dto.TaskResponseDto;
+import site.katchup.katchupserver.api.task.repository.TaskRepository;
+import site.katchup.katchupserver.api.task.service.TaskService;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TaskServiceImpl implements TaskService {
+
+    private final CategoryRepository categoryRepository;
+    private final FolderRepository folderRepository;
+    private final TaskRepository taskRepository;
+
+    @Override
+    public List<TaskResponseDto> getAllTask(Long memberId) {
+
+        return categoryRepository.findByMemberId(memberId).stream()
+                .flatMap(category -> folderRepository.findByCategoryId(category.getId()).stream())
+                .flatMap(folder -> taskRepository.findByFolderId(folder.getId()).stream())
+                .map(task -> TaskResponseDto.of(task.getId(), task.getName()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/site/katchup/katchupserver/api/task/service/TaskService.java
+++ b/src/main/java/site/katchup/katchupserver/api/task/service/TaskService.java
@@ -1,0 +1,9 @@
+package site.katchup.katchupserver.api.task.service;
+
+import site.katchup.katchupserver.api.task.dto.TaskResponseDto;
+
+import java.util.List;
+
+public interface TaskService {
+    List<TaskResponseDto> getAllTask(Long memberId);
+}

--- a/src/main/java/site/katchup/katchupserver/common/response/SuccessStatus.java
+++ b/src/main/java/site/katchup/katchupserver/common/response/SuccessStatus.java
@@ -11,7 +11,7 @@ import org.springframework.http.HttpStatus;
 public enum SuccessStatus {
   
    /**
-     *auth
+     * auth
      */
     SIGNUP_SUCCESS(HttpStatus.CREATED, "회원가입 성공"),
     SIGNIN_SUCCESS(HttpStatus.OK, "로그인 성공"),
@@ -22,9 +22,14 @@ public enum SuccessStatus {
     READ_ALL_CATEGORY_SUCCESS(HttpStatus.OK, "대분류 카테고리 목록 조회 성공"),
 
     /**
-     *member
+     * member
      */
-    GET_MEMBER_SUCCESS(HttpStatus.OK, "프로필 팝업 조회 성공");
+    GET_MEMBER_SUCCESS(HttpStatus.OK, "프로필 팝업 조회 성공"),
+
+    /**
+     * task
+     */
+    GET_ALL_TASK_SUCCESS(HttpStatus.OK, "업무 소분류 목록 조회 성공");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
업무 소분류 목록 조회 API를 구현하였습니다.


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
**1. 조회할 소분류 목록이 있을 때**
![내용ㅇ 있을때](https://github.com/Katchup-dev/Katchup-server/assets/64405757/45d34c65-3129-4e68-8252-2fb650a7568d)

**2. 조회할 소분류 목록이 없을 때**
![내용 없을 때](https://github.com/Katchup-dev/Katchup-server/assets/64405757/e0e07071-7900-4ed3-9b78-f3929a6424b3)


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
아직 response body에서 code로 뜨는 건 현재 브랜치에서 예슬언니 작업부분 머지가 안되어서 그런 것입니다-!!!
develop에 머지되면 바뀔거에유!!


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #26 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
