### PR TITLE
[FEAT] 특정 카테고리 내 중분류 폴더 조회 API

### DIFF
--- a/src/main/java/site/katchup/katchupserver/api/folder/controller/FolderController.java
+++ b/src/main/java/site/katchup/katchupserver/api/folder/controller/FolderController.java
@@ -1,11 +1,9 @@
 package site.katchup.katchupserver.api.folder.controller;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import site.katchup.katchupserver.api.folder.dto.response.FolderResponseDto;
 import site.katchup.katchupserver.api.folder.service.FolderService;
 import site.katchup.katchupserver.api.member.domain.Member;
@@ -30,5 +28,11 @@ public class FolderController {
         Long memberId = Member.getMemberId(principal);
 
         return ApiResponseDto.success(SuccessStatus.READ_ALL_FOLDER_SUCCESS, folderService.getAllFolder(memberId));
+    }
+
+    @GetMapping("/{categoryId}")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<List<FolderResponseDto>> getByCategoryId(@PathVariable final Long categoryId) {
+        return ApiResponseDto.success(SuccessStatus.READ_BY_CATEGORY_SUCCESS, folderService.getByCategoryId(categoryId));
     }
 }

--- a/src/main/java/site/katchup/katchupserver/api/folder/service/FolderService.java
+++ b/src/main/java/site/katchup/katchupserver/api/folder/service/FolderService.java
@@ -8,4 +8,7 @@ public interface FolderService {
 
     //* 중분류 폴더 전체 목록 조회
     List<FolderResponseDto> getAllFolder(Long memberId);
+
+    //* 특정 카테고리 내 중분류 폴더 목록 조회
+    List<FolderResponseDto> getByCategoryId(Long categoryId);
 }

--- a/src/main/java/site/katchup/katchupserver/api/folder/service/Impl/FolderServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/folder/service/Impl/FolderServiceImpl.java
@@ -3,6 +3,7 @@ package site.katchup.katchupserver.api.folder.service.Impl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import site.katchup.katchupserver.api.category.repository.CategoryRepository;
+import site.katchup.katchupserver.api.folder.domain.Folder;
 import site.katchup.katchupserver.api.folder.dto.response.FolderResponseDto;
 import site.katchup.katchupserver.api.folder.repository.FolderRepository;
 import site.katchup.katchupserver.api.folder.service.FolderService;
@@ -21,6 +22,13 @@ public class FolderServiceImpl implements FolderService {
     public List<FolderResponseDto> getAllFolder(Long memberId) {
         return categoryRepository.findByMemberId(memberId).stream()
                 .flatMap(category -> folderRepository.findByCategoryId(category.getId()).stream())
+                .map(folder -> FolderResponseDto.of(folder.getId(), folder.getName()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<FolderResponseDto> getByCategoryId(Long categoryId) {
+        return folderRepository.findByCategoryId(categoryId).stream()
                 .map(folder -> FolderResponseDto.of(folder.getId(), folder.getName()))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/site/katchup/katchupserver/common/dto/ApiResponseDto.java
+++ b/src/main/java/site/katchup/katchupserver/common/dto/ApiResponseDto.java
@@ -11,7 +11,6 @@ import site.katchup.katchupserver.common.response.SuccessStatus;
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApiResponseDto<T> {
 
     private final int status;

--- a/src/main/java/site/katchup/katchupserver/common/response/SuccessStatus.java
+++ b/src/main/java/site/katchup/katchupserver/common/response/SuccessStatus.java
@@ -11,7 +11,7 @@ import org.springframework.http.HttpStatus;
 public enum SuccessStatus {
   
    /**
-     *auth
+     * auth
      */
     SIGNUP_SUCCESS(HttpStatus.CREATED, "회원가입 성공"),
     SIGNIN_SUCCESS(HttpStatus.OK, "로그인 성공"),
@@ -25,9 +25,10 @@ public enum SuccessStatus {
      * folder
      */
     READ_ALL_FOLDER_SUCCESS(HttpStatus.OK, "중분류 폴더 전체 목록 조회 성공"),
+    READ_BY_CATEGORY_SUCCESS(HttpStatus.OK, "특정 카테고리 내 중분류 폴더 조회 성공"),
 
     /**
-     *member
+     * member
      */
     GET_MEMBER_SUCCESS(HttpStatus.OK, "프로필 팝업 조회 성공");
 


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
- 특정 카테고리 내 중분류 폴더를 조회하는 API를 개발합니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- PathVariable로 조회하고 싶은 카테고리 id를 받아서 해당 카테고리 내의 있는 중분류 폴더 목록을 조회하도록 구현했습니다.
- Category 테이블은 member_id를 FK로 가지고 있으므로, 해당 API에서는 pricipal 객체에서 memberId를 가져오는 로직이 필요 없다고 생각해서 생략했습니다.
- Discussion에 나왔던 사항을 토대로 @JsonInclude 어노테이션 제거 했습니다.

<img width="853" alt="image" src="https://github.com/Katchup-dev/Katchup-server/assets/68415644/5a407f8d-8527-48d2-9390-10aab7a09d9b">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #28 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
