### PR TITLE
[REFACTOR] getMemberId 메소드 MemberUtil 클래스로 분리

### DIFF
--- a/src/main/java/site/katchup/katchupserver/api/category/controller/CategoryController.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/controller/CategoryController.java
@@ -5,9 +5,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import site.katchup.katchupserver.api.category.dto.response.CategoryResponseDto;
 import site.katchup.katchupserver.api.category.service.CategoryService;
-import site.katchup.katchupserver.api.member.domain.Member;
 import site.katchup.katchupserver.common.dto.ApiResponseDto;
 import site.katchup.katchupserver.common.response.SuccessStatus;
+import site.katchup.katchupserver.common.util.MemberUtil;
 
 import java.security.Principal;
 import java.util.List;
@@ -24,8 +24,7 @@ public class CategoryController {
     @GetMapping()
     @ResponseStatus(HttpStatus.OK)
     public ApiResponseDto<List<CategoryResponseDto>> getAllCategory(Principal principal) {
-        Long memberId = Member.getMemberId(principal);
-
+        Long memberId = MemberUtil.getMemberId(principal);
         return ApiResponseDto.success(SuccessStatus.READ_ALL_CATEGORY_SUCCESS, categoryService.getAllCategory(memberId));
     }
 

--- a/src/main/java/site/katchup/katchupserver/api/category/dto/response/CategoryResponseDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/dto/response/CategoryResponseDto.java
@@ -13,7 +13,7 @@ public class CategoryResponseDto {
 
     private Long categoryId;
     private String name;
-    private boolean isShared;
+    private Boolean isShared;
 
     public static CategoryResponseDto of(Long categoryId, String name, boolean isShared) {
         return new CategoryResponseDto(categoryId, name, isShared);

--- a/src/main/java/site/katchup/katchupserver/api/folder/controller/FolderController.java
+++ b/src/main/java/site/katchup/katchupserver/api/folder/controller/FolderController.java
@@ -9,6 +9,7 @@ import site.katchup.katchupserver.api.folder.service.FolderService;
 import site.katchup.katchupserver.api.member.domain.Member;
 import site.katchup.katchupserver.common.dto.ApiResponseDto;
 import site.katchup.katchupserver.common.response.SuccessStatus;
+import site.katchup.katchupserver.common.util.MemberUtil;
 
 import java.security.Principal;
 import java.util.List;
@@ -25,8 +26,7 @@ public class FolderController {
     @GetMapping()
     @ResponseStatus(HttpStatus.OK)
     public ApiResponseDto<List<FolderResponseDto>> getAllCategory(Principal principal) {
-        Long memberId = Member.getMemberId(principal);
-
+        Long memberId = MemberUtil.getMemberId(principal);
         return ApiResponseDto.success(SuccessStatus.READ_ALL_FOLDER_SUCCESS, folderService.getAllFolder(memberId));
     }
 

--- a/src/main/java/site/katchup/katchupserver/api/member/controller/MemberController.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import site.katchup.katchupserver.api.member.dto.MemberResponseDto;
 import site.katchup.katchupserver.api.member.service.MemberService;
 import site.katchup.katchupserver.common.dto.ApiResponseDto;
 import site.katchup.katchupserver.common.response.SuccessStatus;
+import site.katchup.katchupserver.common.util.MemberUtil;
 
 import java.security.Principal;
 
@@ -18,7 +19,7 @@ public class MemberController {
 
     @GetMapping("/profile")
     public ApiResponseDto<MemberResponseDto> getMemberProfile(Principal principal) {
-        Long memberId = Member.getMemberId(principal);
+        Long memberId = MemberUtil.getMemberId(principal);
 
         MemberResponseDto responseDto = memberService.getMemberProfile(memberId);
 

--- a/src/main/java/site/katchup/katchupserver/api/member/domain/Member.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/domain/Member.java
@@ -55,11 +55,5 @@ public class Member extends BaseEntity {
         this.refreshToken = refreshToken;
     }
 
-    public static Long getMemberId(Principal principal) {
-        if (isNull(principal)) {
-            throw new CustomException(ErrorStatus.INVALID_MEMBER);
-        }
-        return Long.valueOf(principal.getName());
-    }
 }
 

--- a/src/main/java/site/katchup/katchupserver/api/task/controller/TaskController.java
+++ b/src/main/java/site/katchup/katchupserver/api/task/controller/TaskController.java
@@ -11,6 +11,7 @@ import site.katchup.katchupserver.api.task.dto.TaskResponseDto;
 import site.katchup.katchupserver.api.task.service.TaskService;
 import site.katchup.katchupserver.common.dto.ApiResponseDto;
 import site.katchup.katchupserver.common.response.SuccessStatus;
+import site.katchup.katchupserver.common.util.MemberUtil;
 
 import java.security.Principal;
 import java.util.List;
@@ -24,8 +25,7 @@ public class TaskController {
     @GetMapping()
     @ResponseStatus(HttpStatus.OK)
     public ApiResponseDto<List<TaskResponseDto>> getAllTask(Principal principal) {
-        Long memberId = Member.getMemberId(principal);
-
+        Long memberId = MemberUtil.getMemberId(principal);
         return ApiResponseDto.success(SuccessStatus.GET_ALL_TASK_SUCCESS, taskService.getAllTask(memberId));
     }
 }

--- a/src/main/java/site/katchup/katchupserver/common/util/MemberUtil.java
+++ b/src/main/java/site/katchup/katchupserver/common/util/MemberUtil.java
@@ -1,0 +1,18 @@
+package site.katchup.katchupserver.common.util;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import site.katchup.katchupserver.common.exception.CustomException;
+import site.katchup.katchupserver.common.response.ErrorStatus;
+
+import java.security.Principal;
+
+@RequiredArgsConstructor
+public class MemberUtil {
+    public static Long getMemberId(Principal principal) {
+        if (principal == null) {
+            throw new CustomException(ErrorStatus.INVALID_MEMBER);
+        }
+        return Long.valueOf(principal.getName());
+    }
+}


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
- getMemberId 메소드 MemberUtil 클래스로 분리하는 리팩토링 진행했습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- Member 엔티티 내부에 static method로 구현되어있던 getMemberId 메소드를 commom > util > MemberUtil 클래스로 빼는 리팩토링 진행했습니다.

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #35 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
