### PR TITLE
[FEAT] 스크린샷 추가 API

### DIFF
--- a/src/main/java/site/katchup/katchupserver/api/screenshot/controller/ScreenshotController.java
+++ b/src/main/java/site/katchup/katchupserver/api/screenshot/controller/ScreenshotController.java
@@ -19,7 +19,7 @@ public class ScreenshotController {
     private final ScreenshotService screenshotService;
 
     @PostMapping("/cards/{cardId}/screenshot")
-    @ResponseStatus(HttpStatus.OK)
+    @ResponseStatus(HttpStatus.CREATED)
     public ApiResponseDto<UploadScreenshotResponseDTO> uploadScreenshot(
             Principal principal,
             @PathVariable Long cardId,

--- a/src/main/java/site/katchup/katchupserver/api/screenshot/controller/ScreenshotController.java
+++ b/src/main/java/site/katchup/katchupserver/api/screenshot/controller/ScreenshotController.java
@@ -1,0 +1,33 @@
+package site.katchup.katchupserver.api.screenshot.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import site.katchup.katchupserver.api.screenshot.dto.response.UploadScreenshotResponseDTO;
+import site.katchup.katchupserver.api.screenshot.service.ScreenshotService;
+import site.katchup.katchupserver.common.dto.ApiResponseDto;
+import site.katchup.katchupserver.common.response.SuccessStatus;
+import site.katchup.katchupserver.common.util.MemberUtil;
+
+import java.security.Principal;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class ScreenshotController {
+
+    private final ScreenshotService screenshotService;
+
+    @PostMapping("/cards/{cardId}/screenshot")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<UploadScreenshotResponseDTO> uploadScreenshot(
+            Principal principal,
+            @PathVariable("cardId") Long cardId,
+            @RequestPart MultipartFile file
+    ) {
+        return ApiResponseDto.success(SuccessStatus.UPLOAD_SCREENSHOT_SUCCESS, screenshotService.uploadScreenshot(file, cardId));
+    }
+
+}

--- a/src/main/java/site/katchup/katchupserver/api/screenshot/controller/ScreenshotController.java
+++ b/src/main/java/site/katchup/katchupserver/api/screenshot/controller/ScreenshotController.java
@@ -2,14 +2,12 @@ package site.katchup.katchupserver.api.screenshot.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import site.katchup.katchupserver.api.screenshot.dto.response.UploadScreenshotResponseDTO;
 import site.katchup.katchupserver.api.screenshot.service.ScreenshotService;
 import site.katchup.katchupserver.common.dto.ApiResponseDto;
 import site.katchup.katchupserver.common.response.SuccessStatus;
-import site.katchup.katchupserver.common.util.MemberUtil;
 
 import java.security.Principal;
 
@@ -24,7 +22,7 @@ public class ScreenshotController {
     @ResponseStatus(HttpStatus.OK)
     public ApiResponseDto<UploadScreenshotResponseDTO> uploadScreenshot(
             Principal principal,
-            @PathVariable("cardId") Long cardId,
+            @PathVariable Long cardId,
             @RequestPart MultipartFile file
     ) {
         return ApiResponseDto.success(SuccessStatus.UPLOAD_SCREENSHOT_SUCCESS, screenshotService.uploadScreenshot(file, cardId));

--- a/src/main/java/site/katchup/katchupserver/api/screenshot/domain/Screenshot.java
+++ b/src/main/java/site/katchup/katchupserver/api/screenshot/domain/Screenshot.java
@@ -10,7 +10,6 @@ import site.katchup.katchupserver.common.domain.BaseEntity;
 import static jakarta.persistence.FetchType.LAZY;
 import java.util.UUID;
 
-import static java.util.UUID.randomUUID;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
@@ -20,8 +19,8 @@ public class Screenshot extends BaseEntity {
     @Id
     private UUID id;
 
-    @Column(nullable = false)
-    private int tag_order;
+    @Column(name="sticker_order", columnDefinition = "integer default 0")
+    private int stickerOrder;
 
     @Column(nullable = false)
     private String url;
@@ -31,11 +30,14 @@ public class Screenshot extends BaseEntity {
     private Card card;
 
     @Builder
-    public Screenshot(int tag_order, String url, Card card) {
-        this.id = randomUUID();
-        this.tag_order = tag_order;
+    public Screenshot(UUID id, String url, Card card) {
+        this.id = id;
         this.url = url;
         this.card = card;
-        this.card.addScreenshot(this);
     }
+
+    public void updateCard(Card card) {
+        this.card = card;
+    }
+
 }

--- a/src/main/java/site/katchup/katchupserver/api/screenshot/dto/response/UploadScreenshotResponseDTO.java
+++ b/src/main/java/site/katchup/katchupserver/api/screenshot/dto/response/UploadScreenshotResponseDTO.java
@@ -2,7 +2,6 @@ package site.katchup.katchupserver.api.screenshot.dto.response;
 
 import lombok.Builder;
 import lombok.Data;
-import lombok.Getter;
 
 @Data
 public class UploadScreenshotResponseDTO {

--- a/src/main/java/site/katchup/katchupserver/api/screenshot/dto/response/UploadScreenshotResponseDTO.java
+++ b/src/main/java/site/katchup/katchupserver/api/screenshot/dto/response/UploadScreenshotResponseDTO.java
@@ -1,0 +1,18 @@
+package site.katchup.katchupserver.api.screenshot.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+
+@Data
+public class UploadScreenshotResponseDTO {
+
+    private String id;
+    private String screenshotUrl;
+
+    @Builder
+    public UploadScreenshotResponseDTO(String id, String screenshotUrl) {
+        this.id = id;
+        this.screenshotUrl = screenshotUrl;
+    }
+}

--- a/src/main/java/site/katchup/katchupserver/api/screenshot/service/ScreenshotService.java
+++ b/src/main/java/site/katchup/katchupserver/api/screenshot/service/ScreenshotService.java
@@ -1,0 +1,10 @@
+package site.katchup.katchupserver.api.screenshot.service;
+
+import org.springframework.web.multipart.MultipartFile;
+import site.katchup.katchupserver.api.screenshot.dto.response.UploadScreenshotResponseDTO;
+
+public interface ScreenshotService {
+
+    UploadScreenshotResponseDTO uploadScreenshot(MultipartFile file, Long cardId);
+
+}

--- a/src/main/java/site/katchup/katchupserver/api/screenshot/service/ScreenshotServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/screenshot/service/ScreenshotServiceImpl.java
@@ -22,9 +22,9 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.UUID;
 
-@RequiredArgsConstructor
-@Transactional(readOnly = true)
 @Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class ScreenshotServiceImpl implements ScreenshotService{
 
     private static final String SCREENSHOT_FOLDER_NAME = "screenshots";

--- a/src/main/java/site/katchup/katchupserver/api/screenshot/service/ScreenshotServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/screenshot/service/ScreenshotServiceImpl.java
@@ -1,0 +1,98 @@
+package site.katchup.katchupserver.api.screenshot.service;
+
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import site.katchup.katchupserver.api.card.domain.Card;
+import site.katchup.katchupserver.api.card.repository.CardRepository;
+import site.katchup.katchupserver.api.screenshot.domain.Screenshot;
+import site.katchup.katchupserver.api.screenshot.dto.response.UploadScreenshotResponseDTO;
+import site.katchup.katchupserver.api.screenshot.repository.ScreenshotRepository;
+import site.katchup.katchupserver.common.exception.CustomException;
+import site.katchup.katchupserver.common.response.ErrorStatus;
+import site.katchup.katchupserver.common.util.S3Util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Transactional()
+@Service
+public class ScreenshotServiceImpl implements ScreenshotService{
+
+    private static final String SCREENSHOT_FOLDER_NAME = "screenshots";
+
+    private final S3Util s3Util;
+
+    private final ScreenshotValidator screenshotValidator;
+
+    private final ScreenshotRepository screenshotRepository;
+
+    private final CardRepository cardRepository;
+
+    @Override
+    @Transactional
+    public UploadScreenshotResponseDTO uploadScreenshot(MultipartFile file, Long cardId) {
+        screenshotValidator.validate(file);
+        final String imageId = getUUIDFileName();
+        String uploadFilePath = SCREENSHOT_FOLDER_NAME + "/" + getFoldername();
+        String uploadFileName = uploadFilePath + "/" + imageId + extractExtension(file);
+
+        try {
+            String uploadImageUrl = s3Util.upload(getInputStream(file), uploadFileName, getObjectMetadata(file));
+            Screenshot screenshot =  Screenshot.builder()
+                    .id(UUID.fromString(imageId))
+                    .url(uploadImageUrl)
+                    .card(getCardById(cardId))
+                    .build();
+
+            screenshotRepository.save(screenshot);
+
+            return new UploadScreenshotResponseDTO(screenshot.getId().toString(), screenshot.getUrl());
+
+        } catch (IOException e) {
+            throw new CustomException(ErrorStatus.IMAGE_UPLOAD_EXCEPTION);
+        }
+    }
+
+
+    private String getUUIDFileName() {
+        return UUID.randomUUID().toString();
+    }
+
+    private Card getCardById(Long cardId) {
+        return cardRepository.findById(cardId).orElseThrow(() -> new EntityNotFoundException("해당 카드를 찾을 수 없습니다."));
+    }
+
+    private String getFoldername() {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault());
+        Date date = new Date();
+        return sdf.format(date).replace("-", "/");
+    }
+
+    private ObjectMetadata getObjectMetadata(MultipartFile file) {
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(file.getSize());
+        objectMetadata.setContentType(file.getContentType());
+        return objectMetadata;
+    }
+
+    private InputStream getInputStream(MultipartFile file) throws IOException {
+        return file.getInputStream();
+    }
+
+    private String extractExtension(MultipartFile file) {
+        try {
+            return file.getOriginalFilename().substring(file.getOriginalFilename().lastIndexOf("."));
+        } catch (StringIndexOutOfBoundsException e) {
+            throw new CustomException(ErrorStatus.IMAGE_UPLOAD_EXCEPTION);
+        }
+    }
+}

--- a/src/main/java/site/katchup/katchupserver/api/screenshot/service/ScreenshotServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/screenshot/service/ScreenshotServiceImpl.java
@@ -64,8 +64,7 @@ public class ScreenshotServiceImpl implements ScreenshotService{
             throw new CustomException(ErrorStatus.IMAGE_UPLOAD_EXCEPTION);
         }
     }
-
-
+    
     private String getUUIDFileName() {
         return UUID.randomUUID().toString();
     }

--- a/src/main/java/site/katchup/katchupserver/api/screenshot/service/ScreenshotServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/screenshot/service/ScreenshotServiceImpl.java
@@ -23,7 +23,7 @@ import java.util.Locale;
 import java.util.UUID;
 
 @RequiredArgsConstructor
-@Transactional()
+@Transactional(readOnly = true)
 @Service
 public class ScreenshotServiceImpl implements ScreenshotService{
 
@@ -55,7 +55,10 @@ public class ScreenshotServiceImpl implements ScreenshotService{
 
             screenshotRepository.save(screenshot);
 
-            return new UploadScreenshotResponseDTO(screenshot.getId().toString(), screenshot.getUrl());
+            return UploadScreenshotResponseDTO.builder()
+                    .id(screenshot.getId().toString())
+                    .screenshotUrl(screenshot.getUrl())
+                    .build();
 
         } catch (IOException e) {
             throw new CustomException(ErrorStatus.IMAGE_UPLOAD_EXCEPTION);

--- a/src/main/java/site/katchup/katchupserver/api/screenshot/service/ScreenshotValidator.java
+++ b/src/main/java/site/katchup/katchupserver/api/screenshot/service/ScreenshotValidator.java
@@ -27,5 +27,4 @@ public class ScreenshotValidator {
                 throw new IllegalArgumentException("5MB 미만의 파일을 업로드해야합니다.");
         }
     }
-
 }

--- a/src/main/java/site/katchup/katchupserver/api/screenshot/service/ScreenshotValidator.java
+++ b/src/main/java/site/katchup/katchupserver/api/screenshot/service/ScreenshotValidator.java
@@ -1,0 +1,31 @@
+package site.katchup.katchupserver.api.screenshot.service;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+@Component
+public class ScreenshotValidator {
+    private static final Set<String> VALID_CONTENT_TYPES = new HashSet<>(Arrays.asList("image/png", "image/jpg", "image/jpeg", "image/gif","image/tiff", "image/tif"));
+
+    // 5MB
+    private static final long MAX_FILE_SIZE = 5 * 1024 * 1024;
+
+    public void validate(MultipartFile file) throws IllegalArgumentException{
+            if (file.isEmpty()) {
+                throw new IllegalArgumentException("빈 파일입니다.");
+            }
+
+            if (!VALID_CONTENT_TYPES.contains(file.getContentType())) {
+                throw new IllegalArgumentException("지원하지 않는 파일 형식입니다.");
+            }
+
+            if (file.getSize() > MAX_FILE_SIZE) {
+                throw new IllegalArgumentException("5MB 미만의 파일을 업로드해야합니다.");
+        }
+    }
+
+}

--- a/src/main/java/site/katchup/katchupserver/common/response/ErrorStatus.java
+++ b/src/main/java/site/katchup/katchupserver/common/response/ErrorStatus.java
@@ -26,7 +26,8 @@ public enum ErrorStatus {
      */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "예상치 못한 서버 에러가 발생했습니다."),
     BAD_GATEWAY_EXCEPTION(HttpStatus.BAD_GATEWAY, "일시적인 에러가 발생하였습니다.\n잠시 후 다시 시도해주세요!"),
-    SERVICE_UNAVAILABLE_EXCEPTION(HttpStatus.SERVICE_UNAVAILABLE, "현재 점검 중입니다.\n잠시 후 다시 시도해주세요!");
+    SERVICE_UNAVAILABLE_EXCEPTION(HttpStatus.SERVICE_UNAVAILABLE, "현재 점검 중입니다.\n잠시 후 다시 시도해주세요!"),
+    IMAGE_UPLOAD_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패하였습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/site/katchup/katchupserver/common/response/SuccessStatus.java
+++ b/src/main/java/site/katchup/katchupserver/common/response/SuccessStatus.java
@@ -35,7 +35,12 @@ public enum SuccessStatus {
     /**
      * task
      */
-    GET_ALL_TASK_SUCCESS(HttpStatus.OK, "업무 소분류 목록 조회 성공");
+    GET_ALL_TASK_SUCCESS(HttpStatus.OK, "업무 소분류 목록 조회 성공"),
+
+    /**
+     * screenshot
+     */
+    UPLOAD_SCREENSHOT_SUCCESS(HttpStatus.OK, "스크린샷 추가 성공");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/site/katchup/katchupserver/common/response/SuccessStatus.java
+++ b/src/main/java/site/katchup/katchupserver/common/response/SuccessStatus.java
@@ -40,7 +40,7 @@ public enum SuccessStatus {
     /**
      * screenshot
      */
-    UPLOAD_SCREENSHOT_SUCCESS(HttpStatus.OK, "스크린샷 추가 성공");
+    UPLOAD_SCREENSHOT_SUCCESS(HttpStatus.CREATED, "스크린샷 추가 성공");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/site/katchup/katchupserver/common/util/S3Util.java
+++ b/src/main/java/site/katchup/katchupserver/common/util/S3Util.java
@@ -1,11 +1,13 @@
 package site.katchup.katchupserver.common.util;
 
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import site.katchup.katchupserver.config.AwsS3Config;
 
+import java.io.InputStream;
 import java.net.URLDecoder;
 
 @Configuration
@@ -18,8 +20,8 @@ public class S3Util {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
     // 파일 업로드
-    public String upload(String fileName, String filePath) {
-        awsS3Config.amazonS3Client().putObject(bucket, fileName, filePath);
+    public String upload(InputStream file, String fileName, ObjectMetadata objectMetadata) {
+        awsS3Config.amazonS3Client().putObject(bucket, fileName, file, objectMetadata);
         return awsS3Config.amazonS3Client().getUrl(bucket, fileName).toString();
     }
 
@@ -27,5 +29,9 @@ public class S3Util {
     public void delete(String fileName) {
         String key = URLDecoder.decode(fileName.split("/")[3]);
         awsS3Config.amazonS3Client().deleteObject(bucket, key);
+    }
+
+    public String getImageUrl(String filePath) {
+        return awsS3Config.amazonS3Client().getUrl(bucket, filePath).toString();
     }
 }

--- a/src/test/java/site/katchup/katchupserver/api/screenshot/domain/ScreenshotTest.java
+++ b/src/test/java/site/katchup/katchupserver/api/screenshot/domain/ScreenshotTest.java
@@ -28,8 +28,10 @@ class ScreenshotTest {
         Task task = Task.builder().folder(folder).name("Test Task").build();
         Card card = Card.builder().placement_order(1L).isDeleted(false).task(task).build();
 
+        UUID uuid = UUID.randomUUID();
+
         Screenshot screenshot = Screenshot.builder()
-                .tag_order(1)
+                .id(uuid)
                 .url("https://example.com/katchup_screenshot.png")
                 .card(card)
                 .build();
@@ -39,21 +41,9 @@ class ScreenshotTest {
 
         // Then
         Assertions.assertNotNull(savedScreenshot.getId());
-        Assertions.assertTrue(isValidUUID(savedScreenshot.getId().toString()));
-        Assertions.assertEquals(savedScreenshot.getId().toString(), screenshot.getId().toString());
-        Assertions.assertEquals(savedScreenshot.getTag_order(), screenshot.getTag_order());
+        Assertions.assertEquals(savedScreenshot.getId(), uuid);
+        Assertions.assertEquals(savedScreenshot.getStickerOrder(), 0);
         Assertions.assertEquals(savedScreenshot.getUrl(), screenshot.getUrl());
         Assertions.assertEquals(savedScreenshot.getCard().getId(), screenshot.getCard().getId());
     }
-
-    private boolean isValidUUID(String uuidString) {
-        try {
-            UUID.fromString(uuidString);
-            return true;
-        } catch (IllegalArgumentException e) {
-            return false;
-        }
-    }
-
-
 }


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
- 스크린 샷을 추가하는 API를 개발 했습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- S3Util class에 putObject method에 parameter가 부족하여 추가했고 imageUrl 갖고 오는 method 구현했습니다.
- Screenshot API 구현했습니다. 
- **컬럼명 `tag_order`에서 `sticker_order`로 바꿨습니다.**
- Screenshot Entity 생성자 수정했습니다. 
<img width="930" alt="image" src="https://github.com/Katchup-dev/Katchup-server/assets/81692211/606c4d19-9ebc-4c5b-8052-10538406de59">
ㅌ
## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #19 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
