### PR TITLE
[FEAT] 토큰 재발급 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ dependencies {
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+	implementation 'com.auth0:java-jwt:4.4.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/site/katchup/katchupserver/api/auth/controller/AuthController.java
+++ b/src/main/java/site/katchup/katchupserver/api/auth/controller/AuthController.java
@@ -1,18 +1,23 @@
 package site.katchup.katchupserver.api.auth.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import site.katchup.katchupserver.api.auth.dto.AuthRequestDto;
 import site.katchup.katchupserver.api.auth.dto.AuthResponseDto;
+import site.katchup.katchupserver.api.auth.dto.AuthTokenResponseDto;
 import site.katchup.katchupserver.api.auth.service.AuthService;
 import site.katchup.katchupserver.common.dto.ApiResponseDto;
 import site.katchup.katchupserver.common.response.SuccessStatus;
+import site.katchup.katchupserver.config.jwt.JwtTokenProvider;
 
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
 public class AuthController {
     private final AuthService authService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping()
     public ApiResponseDto<AuthResponseDto> socialLogin(@RequestBody AuthRequestDto authRequestDto) {
@@ -26,5 +31,14 @@ public class AuthController {
 
         // 회원가입
         return ApiResponseDto.success(SuccessStatus.SIGNUP_SUCCESS, responseDto);
+    }
+
+    @GetMapping("/token")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<AuthTokenResponseDto> getNewToken(HttpServletRequest request) {
+        String accessToken = (String) request.getAttribute("newAccessToken");
+        String refreshToken = jwtTokenProvider.resolveRefreshToken(request);
+
+        return ApiResponseDto.success(SuccessStatus.GET_NEW_TOKEN_SUCCESS, authService.getNewToken(accessToken, refreshToken));
     }
 }

--- a/src/main/java/site/katchup/katchupserver/api/auth/dto/AuthTokenResponseDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/auth/dto/AuthTokenResponseDto.java
@@ -1,0 +1,12 @@
+package site.katchup.katchupserver.api.auth.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class AuthTokenResponseDto {
+    private String accessToken;
+
+    private String refreshToken;
+}

--- a/src/main/java/site/katchup/katchupserver/api/auth/service/AuthService.java
+++ b/src/main/java/site/katchup/katchupserver/api/auth/service/AuthService.java
@@ -6,6 +6,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import site.katchup.katchupserver.api.auth.dto.AuthRequestDto;
 import site.katchup.katchupserver.api.auth.dto.AuthResponseDto;
+import site.katchup.katchupserver.api.auth.dto.AuthTokenResponseDto;
 import site.katchup.katchupserver.api.auth.dto.GoogleInfoDto;
 import site.katchup.katchupserver.api.member.domain.Member;
 import site.katchup.katchupserver.api.member.repository.MemberRepository;
@@ -60,6 +61,13 @@ public class AuthService {
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .isNewUser(signedMember.isNewUser())
+                .build();
+    }
+
+    public AuthTokenResponseDto getNewToken(String accessToken, String refreshToken) {
+        return AuthTokenResponseDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .build();
     }
 

--- a/src/main/java/site/katchup/katchupserver/api/member/domain/Member.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/domain/Member.java
@@ -55,5 +55,8 @@ public class Member extends BaseEntity {
         this.refreshToken = refreshToken;
     }
 
+    public void updateRefreshToken(String newRefreshToken) {
+        this.refreshToken = newRefreshToken;
+    }
 }
 

--- a/src/main/java/site/katchup/katchupserver/api/member/repository/MemberRepository.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/repository/MemberRepository.java
@@ -11,4 +11,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
 
     Optional<Member> findByEmail(String email);
+
+    Optional<Object> findByIdAndRefreshToken(Long memberId, String refreshToken);
 }

--- a/src/main/java/site/katchup/katchupserver/common/response/ErrorStatus.java
+++ b/src/main/java/site/katchup/katchupserver/common/response/ErrorStatus.java
@@ -13,6 +13,7 @@ public enum ErrorStatus {
      */
     VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     VALIDATION_REQUEST_MISSING_EXCEPTION(HttpStatus.BAD_REQUEST, "요청값이 입력되지 않았습니다."),
+    NO_TOKEN(HttpStatus.BAD_REQUEST, "토큰을 넣어주세요."),
 
     /**
      * 401 UNAUTHORIZED
@@ -20,6 +21,8 @@ public enum ErrorStatus {
     UNAUTHORIZED_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     INVALID_MEMBER(HttpStatus.UNAUTHORIZED, "유효하지 않은 유저입니다."),
     GOOGLE_UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "구글 로그인 실패. 만료되었거나 잘못된 구글 토큰입니다."),
+    SIGNIN_REQUIRED(HttpStatus.UNAUTHORIZED, "access, refreshToken 모두 만료되었습니다. 재로그인이 필요합니다."),
+    VALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "아직 유효한 accessToken 입니다."),
 
     /**
      * 404 NOT_FOUND

--- a/src/main/java/site/katchup/katchupserver/common/response/SuccessStatus.java
+++ b/src/main/java/site/katchup/katchupserver/common/response/SuccessStatus.java
@@ -15,6 +15,7 @@ public enum SuccessStatus {
      */
     SIGNUP_SUCCESS(HttpStatus.CREATED, "회원가입 성공"),
     SIGNIN_SUCCESS(HttpStatus.OK, "로그인 성공"),
+    GET_NEW_TOKEN_SUCCESS(HttpStatus.OK,"토큰 재발급 성공"),
 
     /**
      * category

--- a/src/main/java/site/katchup/katchupserver/config/SecurityConfig.java
+++ b/src/main/java/site/katchup/katchupserver/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
                 .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                 .anyRequest().permitAll()
                 .and()
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, jwtAuthenticationEntryPoint), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
@@ -61,7 +61,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests()
                 .anyRequest().authenticated()
                 .and()
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, jwtAuthenticationEntryPoint), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/site/katchup/katchupserver/config/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/site/katchup/katchupserver/config/jwt/JwtAuthenticationEntryPoint.java
@@ -23,11 +23,11 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     }
 
 
-    private void setResponse(HttpServletResponse response, ErrorStatus status) throws IOException {
+    public void setResponse(HttpServletResponse response, ErrorStatus status) throws IOException {
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 
-        ApiResponseDto<Object> apiResponse = ApiResponseDto.error(status);
+        ApiResponseDto apiResponse = ApiResponseDto.error(status);
         response.getWriter().println(mapper.writeValueAsString(apiResponse));
     }
 }

--- a/src/main/java/site/katchup/katchupserver/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/site/katchup/katchupserver/config/jwt/JwtAuthenticationFilter.java
@@ -7,7 +7,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.web.filter.OncePerRequestFilter;
 import site.katchup.katchupserver.common.exception.CustomException;
 import site.katchup.katchupserver.common.response.ErrorStatus;
@@ -17,18 +16,50 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
         String accessToken = jwtTokenProvider.resolveToken(request);
-        JwtExceptionType jwtException = jwtTokenProvider.validateToken(accessToken);
 
-        if (accessToken != null) {
-            // 토큰 검증
-            if (jwtException == JwtExceptionType.VALID_JWT_TOKEN) {
-                setAuthentication(accessToken);
+        if (request.getRequestURI().equals("/api/v1/auth/token")) {
+            String refreshToken = jwtTokenProvider.resolveRefreshToken(request);
+
+            if (jwtTokenProvider.validateToken(refreshToken) == JwtExceptionType.EMPTY_JWT || jwtTokenProvider.validateToken(accessToken) == JwtExceptionType.EMPTY_JWT) {
+                jwtAuthenticationEntryPoint.setResponse(response, ErrorStatus.NO_TOKEN);
+                return;
+            } else if (jwtTokenProvider.validateToken(accessToken) == JwtExceptionType.EXPIRED_JWT_TOKEN) {
+                if (jwtTokenProvider.validateToken(refreshToken) == JwtExceptionType.EXPIRED_JWT_TOKEN) {
+                    // access, refresh 둘 다 만료
+                    jwtAuthenticationEntryPoint.setResponse(response, ErrorStatus.SIGNIN_REQUIRED);
+                    return;
+                } else if (jwtTokenProvider.validateToken(refreshToken) == JwtExceptionType.VALID_JWT_TOKEN) {
+                    // 토큰 재발급
+                    Long memberId = jwtTokenProvider.validateMemberRefreshToken(accessToken, refreshToken);
+                    Authentication authentication = new UserAuthentication(memberId, null, null);
+
+                    String newAccessToken = jwtTokenProvider.generateAccessToken(authentication);
+
+                    setAuthentication(newAccessToken);
+                    request.setAttribute("newAccessToken", newAccessToken);
+                }
+            } else if (jwtTokenProvider.validateToken(accessToken) == JwtExceptionType.VALID_JWT_TOKEN) {
+                jwtAuthenticationEntryPoint.setResponse(response, ErrorStatus.VALID_ACCESS_TOKEN);
+                return;
             } else {
                 throw new CustomException(ErrorStatus.UNAUTHORIZED_TOKEN);
+            }
+        }
+        else {
+            JwtExceptionType jwtException = jwtTokenProvider.validateToken(accessToken);
+
+            if (accessToken != null) {
+                // 토큰 검증
+                if (jwtException == JwtExceptionType.VALID_JWT_TOKEN) {
+                    setAuthentication(accessToken);
+                } else {
+                    throw new CustomException(ErrorStatus.UNAUTHORIZED_TOKEN);
+                }
             }
         }
         chain.doFilter(request, response);


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
토큰 재발급 API를 구현하였습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
토큰 재발급 URL로 요청이 들어오면 JwtFilter에서 이를 받아 access, refresh Token의 유효성을 검증한 후 조건에 맞으면 accessToken을 재발급합니다. 

accessToken 유효 -> 401 아직 유효한 accessToken
accessToken 만료, refreshToken 유효 -> 토큰 재발급
accessToken 만료, refreshToken 만료 -> 401 재로그인 필요

**아직 유효한 accessToken**
![아지](https://github.com/Katchup-dev/Katchup-server/assets/64405757/702637c7-d7c0-45f2-ae3c-a8faec2ab6b1)

**토큰 재발급 성공**
![화면 캡처 2023-05-21 154845](https://github.com/Katchup-dev/Katchup-server/assets/64405757/88f38202-88ba-4326-a822-fc9f075472e1)

**access, refresh 모두 만료**
![모두](https://github.com/Katchup-dev/Katchup-server/assets/64405757/63b79cc7-4708-4d99-b40f-ba413bda42e2)

**access나 refresh 헤더에 안 넣음**
![넣어](https://github.com/Katchup-dev/Katchup-server/assets/64405757/58431cf2-a9fd-430e-b6e2-16d91a8b6d90)

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
처음에는 서비스 단에서 해당 로직을 처리하는 방법을 생각했습니다. 하지만 jwtFilter에서 accessToken의 유효성을 검증하고 난 후에 서비스 로직으로 들어오기 때문에 accessToken이 만료된 경우에는 바로 예외로 잡혀버려서 토큰 재발급 서비스 로직을 거치지 않는다는 문제가 있었습니다.
accessToken이 만료된 경우일지라도 refreshToken의 만료 여부를 검증해야 하는데, 그게 안되었다.....!
---> 그래서 jwtFilter 단에서 토큰 재발급 URL을 캐치하여 검증하는 방식으로 구현하였습니다.

더 좋은 구현 방법이 있다면 알려주세요!!!! 😊🍭


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #43 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
