### PR TITLE
[FEAT] 업무 중분류명 수정 API

### DIFF
--- a/src/main/java/site/katchup/katchupserver/api/category/controller/CategoryController.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/controller/CategoryController.java
@@ -37,5 +37,4 @@ public class CategoryController {
         categoryService.updateCategoryName(categoryId, requestDto);
         return ApiResponseDto.success(SuccessStatus.UPDATE_CATEGORY_NAME_SUCCESS);
     }
-
 }

--- a/src/main/java/site/katchup/katchupserver/api/folder/controller/FolderController.java
+++ b/src/main/java/site/katchup/katchupserver/api/folder/controller/FolderController.java
@@ -4,6 +4,8 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import site.katchup.katchupserver.api.category.dto.request.CategoryUpdateRequestDto;
+import site.katchup.katchupserver.api.folder.dto.request.FolderUpdateRequestDto;
 import site.katchup.katchupserver.api.folder.dto.response.FolderResponseDto;
 import site.katchup.katchupserver.api.folder.service.FolderService;
 import site.katchup.katchupserver.api.member.domain.Member;
@@ -34,5 +36,14 @@ public class FolderController {
     @ResponseStatus(HttpStatus.OK)
     public ApiResponseDto<List<FolderResponseDto>> getByCategoryId(@PathVariable final Long categoryId) {
         return ApiResponseDto.success(SuccessStatus.READ_BY_CATEGORY_SUCCESS, folderService.getByCategoryId(categoryId));
+    }
+
+    @PatchMapping("/{folderId}")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto updateFolderName(Principal principal, @PathVariable final Long folderId,
+                                             @RequestBody final FolderUpdateRequestDto requestDto) {
+        Long memberId = MemberUtil.getMemberId(principal);
+        folderService.updateFolderName(folderId, requestDto);
+        return ApiResponseDto.success(SuccessStatus.UPDATE_FOLDER_NAME_SUCCESS);
     }
 }

--- a/src/main/java/site/katchup/katchupserver/api/folder/controller/FolderController.java
+++ b/src/main/java/site/katchup/katchupserver/api/folder/controller/FolderController.java
@@ -1,5 +1,6 @@
 package site.katchup.katchupserver.api.folder.controller;
 
+import jakarta.validation.Valid;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -41,7 +42,7 @@ public class FolderController {
     @PatchMapping("/{folderId}")
     @ResponseStatus(HttpStatus.OK)
     public ApiResponseDto updateFolderName(Principal principal, @PathVariable final Long folderId,
-                                             @RequestBody final FolderUpdateRequestDto requestDto) {
+                                             @RequestBody @Valid final FolderUpdateRequestDto requestDto) {
         Long memberId = MemberUtil.getMemberId(principal);
         folderService.updateFolderName(folderId, requestDto);
         return ApiResponseDto.success(SuccessStatus.UPDATE_FOLDER_NAME_SUCCESS);

--- a/src/main/java/site/katchup/katchupserver/api/folder/domain/Folder.java
+++ b/src/main/java/site/katchup/katchupserver/api/folder/domain/Folder.java
@@ -54,4 +54,8 @@ public class Folder extends BaseEntity {
     public void addTask(Task task) {
         tasks.add(task);
     }
+
+    public void updateFolderName(String folderName) {
+        this.name = folderName;
+    }
 }

--- a/src/main/java/site/katchup/katchupserver/api/folder/dto/request/FolderUpdateRequestDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/folder/dto/request/FolderUpdateRequestDto.java
@@ -1,5 +1,6 @@
 package site.katchup.katchupserver.api.folder.dto.request;
 
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,5 +12,6 @@ import static lombok.AccessLevel.PRIVATE;
 @AllArgsConstructor
 public class FolderUpdateRequestDto {
 
+    @Pattern(regexp = "^[a-zA-Z0-9]*$", message = "이모지 및 특수기호 입력은 불가능합니다. 제외하여 입력해 주세요.")
     private String name;
 }

--- a/src/main/java/site/katchup/katchupserver/api/folder/dto/request/FolderUpdateRequestDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/folder/dto/request/FolderUpdateRequestDto.java
@@ -1,0 +1,15 @@
+package site.katchup.katchupserver.api.folder.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@NoArgsConstructor(access = PRIVATE)
+@AllArgsConstructor
+public class FolderUpdateRequestDto {
+
+    private String name;
+}

--- a/src/main/java/site/katchup/katchupserver/api/folder/dto/request/FolderUpdateRequestDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/folder/dto/request/FolderUpdateRequestDto.java
@@ -12,6 +12,6 @@ import static lombok.AccessLevel.PRIVATE;
 @AllArgsConstructor
 public class FolderUpdateRequestDto {
 
-    @Pattern(regexp = "^[a-zA-Z0-9]*$", message = "이모지 및 특수기호 입력은 불가능합니다. 제외하여 입력해 주세요.")
+    @Pattern(regexp = "^[a-zA-Z0-9가-힣_\\s]*$", message = "이모지 및 특수기호 입력은 불가능합니다. 제외하여 입력해 주세요.")
     private String name;
 }

--- a/src/main/java/site/katchup/katchupserver/api/folder/repository/FolderRepository.java
+++ b/src/main/java/site/katchup/katchupserver/api/folder/repository/FolderRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface FolderRepository extends JpaRepository<Folder, Long> {
     List<Folder> findByCategoryId(Long categoryId);
+
+    boolean existsByCategoryIdAndName(Long id, String name);
 }

--- a/src/main/java/site/katchup/katchupserver/api/folder/service/FolderService.java
+++ b/src/main/java/site/katchup/katchupserver/api/folder/service/FolderService.java
@@ -1,5 +1,7 @@
 package site.katchup.katchupserver.api.folder.service;
 
+import site.katchup.katchupserver.api.category.dto.request.CategoryUpdateRequestDto;
+import site.katchup.katchupserver.api.folder.dto.request.FolderUpdateRequestDto;
 import site.katchup.katchupserver.api.folder.dto.response.FolderResponseDto;
 
 import java.util.List;
@@ -11,4 +13,7 @@ public interface FolderService {
 
     //* 특정 카테고리 내 중분류 폴더 목록 조회
     List<FolderResponseDto> getByCategoryId(Long categoryId);
+
+    //* 중분류명 수정
+    void updateFolderName(Long folderId, FolderUpdateRequestDto folderUpdateRequestDto);
 }

--- a/src/main/java/site/katchup/katchupserver/api/folder/service/Impl/FolderServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/folder/service/Impl/FolderServiceImpl.java
@@ -2,8 +2,12 @@ package site.katchup.katchupserver.api.folder.service.Impl;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.katchup.katchupserver.api.category.domain.Category;
+import site.katchup.katchupserver.api.category.dto.request.CategoryUpdateRequestDto;
 import site.katchup.katchupserver.api.category.repository.CategoryRepository;
 import site.katchup.katchupserver.api.folder.domain.Folder;
+import site.katchup.katchupserver.api.folder.dto.request.FolderUpdateRequestDto;
 import site.katchup.katchupserver.api.folder.dto.response.FolderResponseDto;
 import site.katchup.katchupserver.api.folder.repository.FolderRepository;
 import site.katchup.katchupserver.api.folder.service.FolderService;
@@ -19,6 +23,7 @@ public class FolderServiceImpl implements FolderService {
     private final CategoryRepository categoryRepository;
 
     @Override
+    @Transactional
     public List<FolderResponseDto> getAllFolder(Long memberId) {
         return categoryRepository.findByMemberId(memberId).stream()
                 .flatMap(category -> folderRepository.findByCategoryId(category.getId()).stream())
@@ -27,9 +32,17 @@ public class FolderServiceImpl implements FolderService {
     }
 
     @Override
+    @Transactional
     public List<FolderResponseDto> getByCategoryId(Long categoryId) {
         return folderRepository.findByCategoryId(categoryId).stream()
                 .map(folder -> FolderResponseDto.of(folder.getId(), folder.getName()))
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public void updateFolderName(Long folderId, FolderUpdateRequestDto requestDto) {
+        Folder findFolder = folderRepository.getById(folderId);
+        findFolder.updateFolderName(requestDto.getName());
     }
 }

--- a/src/main/java/site/katchup/katchupserver/api/folder/service/Impl/FolderServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/folder/service/Impl/FolderServiceImpl.java
@@ -3,8 +3,6 @@ package site.katchup.katchupserver.api.folder.service.Impl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import site.katchup.katchupserver.api.category.domain.Category;
-import site.katchup.katchupserver.api.category.dto.request.CategoryUpdateRequestDto;
 import site.katchup.katchupserver.api.category.repository.CategoryRepository;
 import site.katchup.katchupserver.api.folder.domain.Folder;
 import site.katchup.katchupserver.api.folder.dto.request.FolderUpdateRequestDto;
@@ -16,7 +14,6 @@ import site.katchup.katchupserver.common.exception.EntityNotFoundException;
 import site.katchup.katchupserver.common.response.ErrorStatus;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static site.katchup.katchupserver.common.response.ErrorStatus.NOT_FOUND_FOLDER;

--- a/src/main/java/site/katchup/katchupserver/common/advice/ControllerExceptionAdvice.java
+++ b/src/main/java/site/katchup/katchupserver/common/advice/ControllerExceptionAdvice.java
@@ -10,6 +10,9 @@ import site.katchup.katchupserver.common.dto.ApiResponseDto;
 import site.katchup.katchupserver.common.exception.CustomException;
 import site.katchup.katchupserver.common.response.ErrorStatus;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @RestControllerAdvice
 public class ControllerExceptionAdvice {
 
@@ -35,7 +38,10 @@ public class ControllerExceptionAdvice {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(MethodArgumentNotValidException.class)
     protected ApiResponseDto handleMethodArgumentNotValidException(final MethodArgumentNotValidException e) {
-        return ApiResponseDto.error(ErrorStatus.VALIDATION_REQUEST_MISSING_EXCEPTION);
+        String errorMessage = e.getFieldError().getDefaultMessage();
+        if (errorMessage.equals(ErrorStatus.VALIDATION_NAMING_EXCEPTION.getMessage()))
+            return ApiResponseDto.error(ErrorStatus.VALIDATION_NAMING_EXCEPTION);
+        return ApiResponseDto.error(ErrorStatus.VALIDATION_EXCEPTION);
     }
 
     /**

--- a/src/main/java/site/katchup/katchupserver/common/response/ErrorStatus.java
+++ b/src/main/java/site/katchup/katchupserver/common/response/ErrorStatus.java
@@ -13,6 +13,7 @@ public enum ErrorStatus {
      */
     VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     VALIDATION_REQUEST_MISSING_EXCEPTION(HttpStatus.BAD_REQUEST, "요청값이 입력되지 않았습니다."),
+    VALIDATION_NAMING_EXCEPTION(HttpStatus.BAD_REQUEST, "이모지 및 특수기호 입력은 불가능합니다. 제외하여 입력해 주세요."),
     NO_TOKEN(HttpStatus.BAD_REQUEST, "토큰을 넣어주세요."),
     DUPLICATE_FOLDER_NAME(HttpStatus.BAD_REQUEST, "해당 중분류명은 이미 존재합니다. 다른 업무명을 입력해 주세요."),
     DUPLICATE_CATEGORY_NAME(HttpStatus.BAD_REQUEST, "해당 대분류명은 이미 존재합니다. 다른 업무명을 입력해 주세요."),
@@ -42,4 +43,5 @@ public enum ErrorStatus {
 
     private final HttpStatus httpStatus;
     private final String message;
+
 }

--- a/src/main/java/site/katchup/katchupserver/common/response/ErrorStatus.java
+++ b/src/main/java/site/katchup/katchupserver/common/response/ErrorStatus.java
@@ -14,6 +14,8 @@ public enum ErrorStatus {
     VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     VALIDATION_REQUEST_MISSING_EXCEPTION(HttpStatus.BAD_REQUEST, "요청값이 입력되지 않았습니다."),
     NO_TOKEN(HttpStatus.BAD_REQUEST, "토큰을 넣어주세요."),
+    DUPLICATE_FOLDER_NAME(HttpStatus.BAD_REQUEST, "해당 중분류명은 이미 존재합니다. 다른 업무명을 입력해 주세요."),
+    DUPLICATE_CATEGORY_NAME(HttpStatus.BAD_REQUEST, "해당 대분류명은 이미 존재합니다. 다른 업무명을 입력해 주세요."),
 
     /**
      * 401 UNAUTHORIZED

--- a/src/main/java/site/katchup/katchupserver/common/response/SuccessStatus.java
+++ b/src/main/java/site/katchup/katchupserver/common/response/SuccessStatus.java
@@ -28,6 +28,7 @@ public enum SuccessStatus {
      */
     READ_ALL_FOLDER_SUCCESS(HttpStatus.OK, "중분류 폴더 전체 목록 조회 성공"),
     READ_BY_CATEGORY_SUCCESS(HttpStatus.OK, "특정 카테고리 내 중분류 폴더 조회 성공"),
+    UPDATE_FOLDER_NAME_SUCCESS(HttpStatus.OK, "업무 중분류명 수정 성공"),
 
     /**
      * member


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 업무 중분류명을 수정하는 API를 구현했습니다.

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 업무 중분류명을 수정하는 API를 구현했습니다.

    - 해당 카테고리 안에서 업무명이 중복되는 경우에 맞는 400 에러 처리 
    <br>
    <img width="851" alt="image" src="https://github.com/Katchup-dev/Katchup-server/assets/68415644/17d2da84-31b2-4cdf-9378-d9773f76644d">
    <br>

    - 변경하려는 업무명이 영문 대소문자, 한글, 띄어쓰기, 언더바(_)가 아닌 경우에 맞는 400 에러 처리
    <br>
    <img width="833" alt="image" src="https://github.com/Katchup-dev/Katchup-server/assets/68415644/d6f90bf0-30bd-4642-8281-7a3935e7e16c">

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #52 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
