### PR TITLE
[FEAT] 업무 카드 저장 시, 번호스티커도 같이 저장

### DIFF
--- a/src/main/java/site/katchup/katchupserver/api/card/dto/request/CardCreateRequestDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/card/dto/request/CardCreateRequestDto.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import site.katchup.katchupserver.api.screenshot.dto.request.ScreenshotCreateRequestDto;
+import site.katchup.katchupserver.api.sticker.dto.StickerCreateRequestDto;
 
 import java.util.List;
 
@@ -20,8 +21,8 @@ public class CardCreateRequestDto {
     @NotNull(message = "CD-113")
     private List<Long> keywordIdList;
     private List<ScreenshotCreateRequestDto> screenshotList;
+    private StickerCreateRequestDto stickerList;
     private String note;
     @NotBlank(message = "CD-114")
     private String content;
-
 }

--- a/src/main/java/site/katchup/katchupserver/api/card/service/Impl/CardServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/card/service/Impl/CardServiceImpl.java
@@ -21,13 +21,15 @@ import site.katchup.katchupserver.api.screenshot.domain.Screenshot;
 import site.katchup.katchupserver.api.screenshot.dto.request.ScreenshotCreateRequestDto;
 import site.katchup.katchupserver.api.screenshot.dto.response.ScreenshotGetResponseDto;
 import site.katchup.katchupserver.api.screenshot.repository.ScreenshotRepository;
+import site.katchup.katchupserver.api.sticker.domain.Sticker;
+import site.katchup.katchupserver.api.sticker.dto.StickerCreateRequestDto;
+import site.katchup.katchupserver.api.sticker.repository.StickerRepository;
 import site.katchup.katchupserver.api.subTask.domain.SubTask;
 import site.katchup.katchupserver.api.subTask.repository.SubTaskRepository;
 import site.katchup.katchupserver.api.task.domain.Task;
 import site.katchup.katchupserver.api.task.repository.TaskRepository;
 import site.katchup.katchupserver.api.trash.domain.Trash;
 import site.katchup.katchupserver.api.trash.repository.TrashRepository;
-import site.katchup.katchupserver.common.util.S3Util;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -45,7 +47,7 @@ public class CardServiceImpl implements CardService {
     private final TaskRepository taskRepository;
     private final ScreenshotRepository screenshotRepository;
     private final KeywordRepository keywordRepository;
-    private final S3Util s3Util;
+    private final StickerRepository stickerRepository;
 
     @Override
     public List<CardListGetResponseDto> getCardList(Long taskId) {
@@ -100,7 +102,6 @@ public class CardServiceImpl implements CardService {
         }
 
         for (ScreenshotCreateRequestDto screenshotInfo : requestDto.getScreenshotList()) {
-
             Screenshot newScreenshot = Screenshot.builder()
                     .id(screenshotInfo.getScreenshotUUID())
                     .url(screenshotInfo.getScreenshotUrl())
@@ -108,6 +109,17 @@ public class CardServiceImpl implements CardService {
                     .build();
 
             screenshotRepository.save(newScreenshot);
+
+            for (StickerCreateRequestDto stickerInfo : screenshotInfo.getStickerList()) {
+
+                Sticker newSticker = Sticker.builder()
+                        .order(stickerInfo.getOrder())
+                        .x(stickerInfo.getX())
+                        .y(stickerInfo.getY())
+                        .screenshot(newScreenshot)
+                        .build();
+                stickerRepository.save(newSticker);
+            }
         }
     }
 
@@ -159,7 +171,7 @@ public class CardServiceImpl implements CardService {
     private List<ScreenshotGetResponseDto> getScreenshotDtoList(Long cardId) {
         return cardRepository.findByIdOrThrow(cardId).getScreenshots().stream()
                 .map(screenshot -> ScreenshotGetResponseDto
-                        .of(screenshot.getId(), screenshot.getStickerOrder(), screenshot.getUrl())
+                        .of(screenshot.getId(), screenshot.getUrl())
                 ).collect(Collectors.toList());
     }
 

--- a/src/main/java/site/katchup/katchupserver/api/screenshot/domain/Screenshot.java
+++ b/src/main/java/site/katchup/katchupserver/api/screenshot/domain/Screenshot.java
@@ -5,9 +5,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.katchup.katchupserver.api.card.domain.Card;
+import site.katchup.katchupserver.api.sticker.domain.Sticker;
 import site.katchup.katchupserver.common.domain.BaseEntity;
 
+import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.FetchType.LAZY;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import static lombok.AccessLevel.PROTECTED;
@@ -19,9 +24,6 @@ public class Screenshot extends BaseEntity {
     @Id
     private UUID id;
 
-    @Column(name="sticker_order", columnDefinition = "integer default 0")
-    private int stickerOrder;
-
     @Column(nullable = false)
     private String url;
 
@@ -29,10 +31,12 @@ public class Screenshot extends BaseEntity {
     @JoinColumn(name = "card_id")
     private Card card;
 
+    @OneToMany(mappedBy = "screenshot", cascade = ALL)
+    private List<Sticker> sticker = new ArrayList<>();
+
     @Builder
     public Screenshot(UUID id, String url, Card card) {
         this.id = id;
-        this.stickerOrder = 0;
         this.url = url;
         this.card = card;
     }

--- a/src/main/java/site/katchup/katchupserver/api/screenshot/dto/request/ScreenshotCreateRequestDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/screenshot/dto/request/ScreenshotCreateRequestDto.java
@@ -4,7 +4,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import site.katchup.katchupserver.api.sticker.dto.StickerCreateRequestDto;
 
+import java.util.List;
 import java.util.UUID;
 
 @Getter
@@ -14,7 +16,11 @@ public class ScreenshotCreateRequestDto {
     @Schema(description = "업로드하는 스크린샷 고유 UUID", example = "ddwd-wdwd-wdwd-wdwdwdwd")
     @NotNull
     private UUID screenshotUUID;
+
     @Schema(description = "스크린샷 url", example = "https://abde.s3.ap-northeast-2.amazonaws.com/1.png")
     @NotNull
     private String screenshotUrl;
+
+    @Schema(description = "번호 스티커")
+    private List<StickerCreateRequestDto> stickerList;
 }

--- a/src/main/java/site/katchup/katchupserver/api/screenshot/dto/response/ScreenshotGetResponseDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/screenshot/dto/response/ScreenshotGetResponseDto.java
@@ -11,8 +11,7 @@ import java.util.UUID;
 public class ScreenshotGetResponseDto {
     @Schema(description = "스크린샷 고유 id", example = "ddwd-wdwd-wdwd-wdwdwdwd")
     private UUID id;
-    @Schema(description = "스티커 순서", example = "1")
-    private int stickerOrder;
+
     @Schema(description = "스크린샷 url", example = "https://abde.s3.ap-northeast-2.amazonaws.com/1.png")
     private String url;
 }

--- a/src/main/java/site/katchup/katchupserver/api/sticker/domain/Sticker.java
+++ b/src/main/java/site/katchup/katchupserver/api/sticker/domain/Sticker.java
@@ -1,0 +1,42 @@
+package site.katchup.katchupserver.api.sticker.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.katchup.katchupserver.api.screenshot.domain.Screenshot;
+import site.katchup.katchupserver.common.domain.BaseEntity;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Sticker extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @Column(name = "sticker_order")
+    private Integer order;
+
+    @Column(name = "x_coordinate")
+    private Float x;
+
+    @Column(name = "y_coordinate")
+    private Float y;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "screenshot_id")
+    private Screenshot screenshot;
+
+    @Builder
+    public Sticker(Integer order, Float x, Float y, Screenshot screenshot) {
+        this.order = order;
+        this.x = x;
+        this.y = y;
+        this.screenshot = screenshot;
+    }
+}

--- a/src/main/java/site/katchup/katchupserver/api/sticker/dto/StickerCreateRequestDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/sticker/dto/StickerCreateRequestDto.java
@@ -1,0 +1,20 @@
+package site.katchup.katchupserver.api.sticker.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Column;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "번호 스티커 추가 요청 DTO")
+public class StickerCreateRequestDto {
+    @Schema(description = "스티커 번호", example = "2")
+    private Integer order;
+
+    @Schema(description = "스티커 X좌표", example = "300")
+    private Float x;
+
+    @Schema(description = "스티커 Y좌표", example = "400")
+    private Float y;
+}

--- a/src/main/java/site/katchup/katchupserver/api/sticker/repository/StickerRepository.java
+++ b/src/main/java/site/katchup/katchupserver/api/sticker/repository/StickerRepository.java
@@ -1,0 +1,7 @@
+package site.katchup.katchupserver.api.sticker.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.katchup.katchupserver.api.sticker.domain.Sticker;
+
+public interface StickerRepository extends JpaRepository<Sticker, Long> {
+}

--- a/src/main/java/site/katchup/katchupserver/common/response/ErrorCode.java
+++ b/src/main/java/site/katchup/katchupserver/common/response/ErrorCode.java
@@ -38,7 +38,6 @@ public enum ErrorCode {
     NOT_FOUND_KEYWORD("KW-306"),
     NOT_FOUND_SCREENSHOT("SS-307"),
 
-
     /**
      * 500 SERVER_ERROR
      */
@@ -47,5 +46,4 @@ public enum ErrorCode {
     IMAGE_UPLOAD_EXCEPTION("SS-403");
     
     private final String code;
-
 }

--- a/src/test/java/site/katchup/katchupserver/api/screenshot/domain/ScreenshotTest.java
+++ b/src/test/java/site/katchup/katchupserver/api/screenshot/domain/ScreenshotTest.java
@@ -40,6 +40,5 @@ class ScreenshotTest {
         // Then
         Assertions.assertNotNull(savedScreenshot.getId());
         Assertions.assertEquals(savedScreenshot.getId(), uuid);
-        Assertions.assertEquals(savedScreenshot.getStickerOrder(), 0);
     }
 }


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
업무 카드 저장 시, 스크린샷에 붙어있는 번호스티커를 같이 저장합니다.


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
sticker 스키마를 설계하였습니다.
원래 screenshot 스키마에 들어있던 stickerOrder column을 sticker 스키마로 이동했습니다.
클라로부터 스티커 번호순서, X 좌표, Y 좌표 값을 넘겨받아 업무카드 저장 시 같이 저장합니다.
한 개의 스크린샷에 여러 개의 번호스티커를 추가할 수 있습니다.

![화면 캡처 2023-08-22 210748](https://github.com/Katchup-dev/Katchup-server/assets/64405757/2b7a0fae-6f13-44e6-be78-56d6332dc4a0)


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #105 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
