### PR TITLE
[FIX] 업무 카드 생성 시, 세부 업무 작성 안하면 '기타' 업무로 분류 & 업무 내 키워드 목록 조회 로직 수정

### DIFF
--- a/src/main/java/site/katchup/katchupserver/api/card/dto/request/CardCreateRequestDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/card/dto/request/CardCreateRequestDto.java
@@ -1,5 +1,6 @@
 package site.katchup.katchupserver.api.card.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -16,6 +17,7 @@ public class CardCreateRequestDto {
     private Long categoryId;
     @NotNull(message = "CD-111")
     private Long taskId;
+    @Schema(description = "세부 업무 작성 안할 시, 해당 값 0으로")
     @NotNull(message = "CD-112")
     private Long subTaskId;
     @NotNull(message = "CD-113")

--- a/src/main/java/site/katchup/katchupserver/api/card/service/Impl/CardServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/card/service/Impl/CardServiceImpl.java
@@ -39,6 +39,8 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class CardServiceImpl implements CardService {
 
+    private static final String SUB_TASK_ETC_NAME = "기타";
+
     private final SubTaskRepository subTaskRepository;
     private final CardKeywordRepository cardKeywordRepository;
     private final TrashRepository trashRepository;
@@ -82,7 +84,13 @@ public class CardServiceImpl implements CardService {
     @Transactional
     public void createCard(CardCreateRequestDto requestDto) {
 
-        SubTask subTask = subTaskRepository.findByIdOrThrow(requestDto.getSubTaskId());
+        SubTask subTask;
+        if (requestDto.getSubTaskId() == 0) {
+            Task task = taskRepository.findByIdOrThrow(requestDto.getTaskId());
+            subTask = subTaskRepository.findOrCreateEtcSubTask(task, SUB_TASK_ETC_NAME);
+        } else {
+            subTask = subTaskRepository.findByIdOrThrow(requestDto.getSubTaskId());
+        }
 
         Card card = Card.builder()
                 .content(requestDto.getContent())

--- a/src/main/java/site/katchup/katchupserver/api/keyword/controller/KeywordController.java
+++ b/src/main/java/site/katchup/katchupserver/api/keyword/controller/KeywordController.java
@@ -16,24 +16,24 @@ import site.katchup.katchupserver.common.dto.ApiResponseDto;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/cards")
+@RequestMapping("/api/v1/keywords")
 @RequiredArgsConstructor
 @Tag(name = "[Keyword] 키워드 관련 API (V1)")
 public class KeywordController {
     private final KeywordService keywordService;
 
-    @Operation(summary = "업무 카드의 모든 키워드 조회 API")
+    @Operation(summary = "업무 내의 모든 키워드 조회 API")
     @ApiResponses(
             value = {
-                    @ApiResponse(responseCode = "200", description = "카드의 모든 키워드 조회 성공"),
-                    @ApiResponse(responseCode = "400", description = "카드의 모든 키워드 조회 실패", content = @Content),
+                    @ApiResponse(responseCode = "200", description = "업무 내의 모든 키워드 조회 성공"),
+                    @ApiResponse(responseCode = "400", description = "업무 내의 모든 키워드 조회 실패", content = @Content),
                     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
             }
     )
-    @GetMapping("/{cardId}/keywords")
+    @GetMapping("/{taskId}")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponseDto<List<KeywordGetResponseDto>> getAllKeyword(@PathVariable Long cardId) {
-        return ApiResponseDto.success(keywordService.getAllKeyword(cardId));
+    public ApiResponseDto<List<KeywordGetResponseDto>> getAllKeyword(@PathVariable Long taskId) {
+        return ApiResponseDto.success(keywordService.getAllKeyword(taskId));
     }
 
     @Operation(summary = "키워드 생성 API")
@@ -44,7 +44,7 @@ public class KeywordController {
                     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
             }
     )
-    @PostMapping("/keywords")
+    @PostMapping()
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponseDto createKeyword(@Valid @RequestBody KeywordCreateRequestDto requestDto) {
         keywordService.createKeyword(requestDto);

--- a/src/main/java/site/katchup/katchupserver/api/subTask/repository/SubTaskRepository.java
+++ b/src/main/java/site/katchup/katchupserver/api/subTask/repository/SubTaskRepository.java
@@ -3,17 +3,32 @@ package site.katchup.katchupserver.api.subTask.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import site.katchup.katchupserver.api.subTask.domain.SubTask;
+import site.katchup.katchupserver.api.task.domain.Task;
 import site.katchup.katchupserver.common.exception.NotFoundException;
 import site.katchup.katchupserver.common.response.ErrorCode;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface SubTaskRepository extends JpaRepository<SubTask, Long> {
     List<SubTask> findAllByTaskId(Long taskId);
 
+    Optional<SubTask> findSubTaskByTaskAndName(Task task, String name);
+
     default SubTask findByIdOrThrow(Long subTaskId) {
-        return findById(subTaskId).orElseThrow(
-                () -> new NotFoundException(ErrorCode.NOT_FOUND_SUB_TASK));
+        return findById(subTaskId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_SUB_TASK));
+    }
+
+    default SubTask findOrCreateEtcSubTask(Task task, String etcName) {
+        return findSubTaskByTaskAndName(task, etcName)
+                .orElseGet(() -> {
+                    SubTask etcSubTask = SubTask.builder()
+                            .task(task)
+                            .name(etcName)
+                            .build();
+                    return save(etcSubTask);
+                });
     }
 }


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
- 업무 카드 생성 시, 세부 업무 작성 안하면 '기타' 세부 업무로 분류하도록 로직을 구현했습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 업무 카드 생성 시, 세부 업무 작성 안하면 클라분들께 request body 내의 subTaskId를 0으로 받기로 했습니다.
- 해당 값이 0이면 '기타' 세부 업무로 분류하도록 로직을 구현했습니다.

![image](https://github.com/Katchup-dev/Katchup-server/assets/68415644/c823f329-e6a4-491f-bba2-15c853c2eedd)

![image](https://github.com/Katchup-dev/Katchup-server/assets/68415644/c2aa39dc-099f-4b64-ac73-c4d45b90b891)

<img width="509" alt="image" src="https://github.com/Katchup-dev/Katchup-server/assets/68415644/be3d175a-1db4-45ab-80df-70ce3f5db9b2">

- 업무 내의 키워드 목록 조회 API 관련해서도 로직 수정 하였습니다.


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #112 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
