### PR TITLE
[ADD] 업무 카드 조회 시, 번호 스티커도 조회

### DIFF
--- a/src/main/java/site/katchup/katchupserver/api/card/dto/request/CardCreateRequestDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/card/dto/request/CardCreateRequestDto.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import site.katchup.katchupserver.api.screenshot.dto.request.ScreenshotCreateRequestDto;
-import site.katchup.katchupserver.api.sticker.dto.StickerCreateRequestDto;
+import site.katchup.katchupserver.api.sticker.dto.request.StickerCreateRequestDto;
 
 import java.util.List;
 
@@ -14,15 +14,20 @@ import java.util.List;
 public class CardCreateRequestDto {
     @NotNull(message = "CD-110")
     private Long categoryId;
+
     @NotNull(message = "CD-111")
     private Long taskId;
+
     @NotNull(message = "CD-112")
     private Long subTaskId;
+
     @NotNull(message = "CD-113")
     private List<Long> keywordIdList;
+
     private List<ScreenshotCreateRequestDto> screenshotList;
-    private StickerCreateRequestDto stickerList;
+
     private String note;
+
     @NotBlank(message = "CD-114")
     private String content;
 }

--- a/src/main/java/site/katchup/katchupserver/api/card/service/Impl/CardServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/card/service/Impl/CardServiceImpl.java
@@ -22,7 +22,8 @@ import site.katchup.katchupserver.api.screenshot.dto.request.ScreenshotCreateReq
 import site.katchup.katchupserver.api.screenshot.dto.response.ScreenshotGetResponseDto;
 import site.katchup.katchupserver.api.screenshot.repository.ScreenshotRepository;
 import site.katchup.katchupserver.api.sticker.domain.Sticker;
-import site.katchup.katchupserver.api.sticker.dto.StickerCreateRequestDto;
+import site.katchup.katchupserver.api.sticker.dto.request.StickerCreateRequestDto;
+import site.katchup.katchupserver.api.sticker.dto.response.StickerGetResponseDto;
 import site.katchup.katchupserver.api.sticker.repository.StickerRepository;
 import site.katchup.katchupserver.api.subTask.domain.SubTask;
 import site.katchup.katchupserver.api.subTask.repository.SubTaskRepository;
@@ -32,6 +33,7 @@ import site.katchup.katchupserver.api.trash.domain.Trash;
 import site.katchup.katchupserver.api.trash.repository.TrashRepository;
 
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -111,7 +113,6 @@ public class CardServiceImpl implements CardService {
             screenshotRepository.save(newScreenshot);
 
             for (StickerCreateRequestDto stickerInfo : screenshotInfo.getStickerList()) {
-
                 Sticker newSticker = Sticker.builder()
                         .order(stickerInfo.getOrder())
                         .x(stickerInfo.getX())
@@ -171,13 +172,20 @@ public class CardServiceImpl implements CardService {
     private List<ScreenshotGetResponseDto> getScreenshotDtoList(Long cardId) {
         return cardRepository.findByIdOrThrow(cardId).getScreenshots().stream()
                 .map(screenshot -> ScreenshotGetResponseDto
-                        .of(screenshot.getId(), screenshot.getUrl())
-                ).collect(Collectors.toList());
+                        .of(screenshot.getId(), screenshot.getUrl(), getStickerDtoList(screenshot.getId())))
+                                .collect(Collectors.toList());
     }
 
     private List<FileGetResponseDto> getFileDtoList(Long cardId) {
         return cardRepository.findByIdOrThrow(cardId).getFiles().stream()
                 .map(file -> FileGetResponseDto.of(file.getId(), file.getName(), file.getUrl(), file.getSize()))
                 .collect(Collectors.toList());
+    }
+
+    private List<StickerGetResponseDto> getStickerDtoList(UUID screenshotId) {
+        return screenshotRepository.findByIdOrThrow(screenshotId).getSticker().stream()
+                .map(sticker -> StickerGetResponseDto
+                        .of(sticker.getOrder(), sticker.getX(), sticker.getY())
+                ).collect(Collectors.toList());
     }
 }

--- a/src/main/java/site/katchup/katchupserver/api/screenshot/dto/request/ScreenshotCreateRequestDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/screenshot/dto/request/ScreenshotCreateRequestDto.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import site.katchup.katchupserver.api.sticker.dto.StickerCreateRequestDto;
+import site.katchup.katchupserver.api.sticker.dto.request.StickerCreateRequestDto;
 
 import java.util.List;
 import java.util.UUID;

--- a/src/main/java/site/katchup/katchupserver/api/screenshot/dto/response/ScreenshotGetResponseDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/screenshot/dto/response/ScreenshotGetResponseDto.java
@@ -3,7 +3,10 @@ package site.katchup.katchupserver.api.screenshot.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import site.katchup.katchupserver.api.sticker.domain.Sticker;
+import site.katchup.katchupserver.api.sticker.dto.response.StickerGetResponseDto;
 
+import java.util.List;
 import java.util.UUID;
 
 @Getter
@@ -14,4 +17,7 @@ public class ScreenshotGetResponseDto {
 
     @Schema(description = "스크린샷 url", example = "https://abde.s3.ap-northeast-2.amazonaws.com/1.png")
     private String url;
+
+    @Schema(description = "번호 스티커")
+    private List<StickerGetResponseDto> stickerList;
 }

--- a/src/main/java/site/katchup/katchupserver/api/sticker/dto/request/StickerCreateRequestDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/sticker/dto/request/StickerCreateRequestDto.java
@@ -1,0 +1,19 @@
+package site.katchup.katchupserver.api.sticker.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "번호 스티커 추가 요청 DTO")
+public class StickerCreateRequestDto {
+    @Schema(description = "스티커 번호", example = "2")
+    private Integer order;
+
+    @Schema(description = "스티커 X좌표", example = "300")
+    private Float x;
+
+    @Schema(description = "스티커 Y좌표", example = "400")
+    private Float y;
+}

--- a/src/main/java/site/katchup/katchupserver/api/sticker/dto/response/StickerGetResponseDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/sticker/dto/response/StickerGetResponseDto.java
@@ -1,14 +1,17 @@
-package site.katchup.katchupserver.api.sticker.dto;
+package site.katchup.katchupserver.api.sticker.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.persistence.Column;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
 
 @Getter
-@AllArgsConstructor
-@Schema(description = "번호 스티커 추가 요청 DTO")
-public class StickerCreateRequestDto {
+@NoArgsConstructor(access = PRIVATE)
+@AllArgsConstructor(staticName = "of")
+@Schema(description = "번호 스티커 응답 DTO")
+public class StickerGetResponseDto {
     @Schema(description = "스티커 번호", example = "2")
     private Integer order;
 


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
업무 카드 조회 시, 번호 스티커도 조회되도록 코드를 추가하였습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
![화면 캡처 2023-08-23 185402](https://github.com/Katchup-dev/Katchup-server/assets/64405757/59725449-231d-4749-857a-3d5820248611)


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #111 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
