### PR TITLE
[FIX] category, task, subTask id header로 응답

### DIFF
--- a/src/main/java/site/katchup/katchupserver/api/category/controller/CategoryController.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/controller/CategoryController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -37,9 +38,10 @@ public class CategoryController {
             @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     })
     public ApiResponseDto createCategoryName(Principal principal,
-                                             @RequestBody @Valid final CategoryCreateRequestDto requestDto) {
+                                             @RequestBody @Valid final CategoryCreateRequestDto requestDto, HttpServletResponse response) {
         Long memberId = MemberUtil.getMemberId(principal);
-        categoryService.createCategoryName(memberId, requestDto);
+        Long categoryId = categoryService.createCategoryName(memberId, requestDto);
+        response.addHeader("Location", String.valueOf(categoryId));
         return ApiResponseDto.success();
     }
 

--- a/src/main/java/site/katchup/katchupserver/api/category/service/CategoryService.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/service/CategoryService.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public interface CategoryService {
 
-    void createCategoryName(Long memberId, CategoryCreateRequestDto categoryCreateRequestDto);
+    Long createCategoryName(Long memberId, CategoryCreateRequestDto categoryCreateRequestDto);
     List<CategoryGetResponseDto> getAllCategory(Long memberId);
     void updateCategoryName(Long memberId, Long categoryId, CategoryUpdateRequestDto categoryUpdateRequestDto);
     void deleteCategory(Long categoryId);

--- a/src/main/java/site/katchup/katchupserver/api/category/service/Impl/CategoryServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/service/Impl/CategoryServiceImpl.java
@@ -31,14 +31,16 @@ public class CategoryServiceImpl implements CategoryService {
 
     @Override
     @Transactional
-    public void createCategoryName(Long memberId, CategoryCreateRequestDto requestDto) {
+    public Long createCategoryName(Long memberId, CategoryCreateRequestDto requestDto) {
         checkDuplicateCategoryName(memberId, requestDto.getName());
 
-        categoryRepository.save(Category.builder()
+        Category category = categoryRepository.save(Category.builder()
                 .name(requestDto.getName())
                 .member(memberRepository.findByIdOrThrow(memberId))
                 .isShared(false)
                 .build());
+
+        return category.getId();
     }
 
     @Override

--- a/src/main/java/site/katchup/katchupserver/api/subTask/controller/SubTaskController.java
+++ b/src/main/java/site/katchup/katchupserver/api/subTask/controller/SubTaskController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -46,8 +47,9 @@ public class SubTaskController {
                     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
             }
     )
-    public ApiResponseDto createSubTask(@Valid @RequestBody SubTaskCreateRequestDto requestDto) {
-        subTaskService.createSubTask(requestDto);
+    public ApiResponseDto createSubTask(@Valid @RequestBody SubTaskCreateRequestDto requestDto, HttpServletResponse response) {
+        Long subTaskId = subTaskService.createSubTask(requestDto);
+        response.addHeader("Location", String.valueOf(subTaskId));
         return ApiResponseDto.success();
     }
 }

--- a/src/main/java/site/katchup/katchupserver/api/subTask/service/Impl/SubTaskServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/subTask/service/Impl/SubTaskServiceImpl.java
@@ -32,11 +32,13 @@ public class SubTaskServiceImpl implements SubTaskService {
 
     @Override
     @Transactional
-    public void createSubTask(SubTaskCreateRequestDto requestDto) {
+    public Long createSubTask(SubTaskCreateRequestDto requestDto) {
         Task task = taskRepository.findByIdOrThrow(requestDto.getTaskId());
 
         SubTask subTask = new SubTask(requestDto.getName(), task);
 
         subTaskRepository.save(subTask);
+
+        return subTask.getId();
     }
 }

--- a/src/main/java/site/katchup/katchupserver/api/subTask/service/SubTaskService.java
+++ b/src/main/java/site/katchup/katchupserver/api/subTask/service/SubTaskService.java
@@ -8,6 +8,6 @@ import java.util.List;
 public interface SubTaskService {
 
     List<SubTaskGetResponseDto> getAllSubTask(Long taskId);
-    void createSubTask(SubTaskCreateRequestDto requestDto);
+    Long createSubTask(SubTaskCreateRequestDto requestDto);
 
 }

--- a/src/main/java/site/katchup/katchupserver/api/task/controller/TaskController.java
+++ b/src/main/java/site/katchup/katchupserver/api/task/controller/TaskController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,7 +16,6 @@ import site.katchup.katchupserver.api.card.service.CardService;
 import site.katchup.katchupserver.api.task.dto.request.TaskCreateRequestDto;
 import site.katchup.katchupserver.api.task.dto.request.TaskUpdateRequestDto;
 import site.katchup.katchupserver.api.task.dto.response.TaskGetResponseDto;
-import site.katchup.katchupserver.api.task.repository.TaskRepository;
 import site.katchup.katchupserver.api.task.service.TaskService;
 import site.katchup.katchupserver.common.dto.ApiResponseDto;
 import site.katchup.katchupserver.common.util.MemberUtil;
@@ -31,7 +31,6 @@ import static lombok.AccessLevel.PRIVATE;
 @Tag(name = "[Task] 업무 관련 API (V1)")
 public class TaskController {
 
-    private final TaskRepository taskRepository;
     private final CardService cardService;
     private final TaskService taskService;
 
@@ -82,8 +81,9 @@ public class TaskController {
     })
     @PostMapping()
     @ResponseStatus(HttpStatus.CREATED)
-    public ApiResponseDto createTaskName(@RequestBody @Valid final TaskCreateRequestDto requestDto) {
-        taskService.createTaskName(requestDto);
+    public ApiResponseDto createTaskName(@RequestBody @Valid final TaskCreateRequestDto requestDto, HttpServletResponse response) {
+        Long taskId = taskService.createTaskName(requestDto);
+        response.addHeader("Location", String.valueOf(taskId));
         return ApiResponseDto.success();
     }
 

--- a/src/main/java/site/katchup/katchupserver/api/task/service/Impl/TaskServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/task/service/Impl/TaskServiceImpl.java
@@ -55,15 +55,17 @@ public class TaskServiceImpl implements TaskService {
 
     @Override
     @Transactional
-    public void createTaskName(TaskCreateRequestDto requestDto) {
+    public Long createTaskName(TaskCreateRequestDto requestDto) {
         Category findCategory = categoryRepository.findByIdOrThrow(requestDto.getCategoryId());
 
         checkDuplicateTaskName(findCategory.getId(), requestDto.getName());
 
-        taskRepository.save(Task.builder()
+        Task task = taskRepository.save(Task.builder()
                 .name(requestDto.getName())
                 .category(findCategory)
                 .build());
+
+        return task.getId();
     }
 
     @Override

--- a/src/main/java/site/katchup/katchupserver/api/task/service/TaskService.java
+++ b/src/main/java/site/katchup/katchupserver/api/task/service/TaskService.java
@@ -12,7 +12,7 @@ public interface TaskService {
     List<TaskGetResponseDto> getAllTask(Long memberId);
     List<TaskGetResponseDto> getByCategoryId(Long categoryId);
     void updateTaskName(Long taskId, TaskUpdateRequestDto taskUpdateRequestDto);
-    void createTaskName(TaskCreateRequestDto taskCreateRequestDto);
+    Long createTaskName(TaskCreateRequestDto taskCreateRequestDto);
     void deleteTask(Long taskId);
 
 }


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
category, task, subTask 생성 시, 각각의 id를 response header로 응답합니다.

형식 예시)
Key: Location
Value: 17

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
Category 생성
![category](https://github.com/Katchup-dev/Katchup-server/assets/64405757/6c3003c7-f090-4d42-bbfd-8a7b8df7a9fd)

Task 생성
![task](https://github.com/Katchup-dev/Katchup-server/assets/64405757/3b99d9af-93e7-4a67-a76a-0307c6d86775)

SubTask 생성
![subTask](https://github.com/Katchup-dev/Katchup-server/assets/64405757/3b77e559-56f8-43c6-b61c-58bb469dc055)

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #115 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
