### PR TITLE
[FIX] 업무 카드 & 업무 삭제 로직 오류 수정

### DIFF
--- a/src/main/java/site/katchup/katchupserver/api/card/service/CardService.java
+++ b/src/main/java/site/katchup/katchupserver/api/card/service/CardService.java
@@ -11,7 +11,7 @@ import java.util.List;
 @Transactional
 public interface CardService {
 
-    List<CardListGetResponseDto> getCardList(Long folderId);
+    List<CardListGetResponseDto> getCardList(Long taskId);
     CardGetResponseDto getCard(Long cardId);
     void deleteCardList(CardDeleteRequestDto cardDeleteRequestDto);
     void createCard(Long memberId, CardCreateRequestDto cardCreateRequestDto);

--- a/src/main/java/site/katchup/katchupserver/api/card/service/Impl/CardServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/card/service/Impl/CardServiceImpl.java
@@ -63,7 +63,7 @@ public class CardServiceImpl implements CardService {
 
     @Override
     public List<CardListGetResponseDto> getCardList(Long taskId) {
-        return subTaskRepository.findAllByTaskId(taskId).stream()
+        return subTaskRepository.findAllByTaskIdAndNotDeleted(taskId).stream()
                 .flatMap(subTask -> subTask.getCards().stream())
                 .collect(Collectors.groupingBy(Card::getSubTask))  // subTaskId 그룹화
                 .values().stream()

--- a/src/main/java/site/katchup/katchupserver/api/category/repository/CategoryRepository.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/repository/CategoryRepository.java
@@ -4,22 +4,25 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import site.katchup.katchupserver.api.category.domain.Category;
+import site.katchup.katchupserver.api.task.domain.Task;
 import site.katchup.katchupserver.common.exception.NotFoundException;
 import site.katchup.katchupserver.common.response.ErrorCode;
 
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
-    boolean existsByMemberIdAndName(Long memberId, String name);
+    Optional<Category> findByIdAndIsDeletedFalse(Long id);
 
+    boolean existsByMemberIdAndName(Long memberId, String name);
 
     @Query("select c from Category c where c.member.id = :memberId and c.isDeleted = false")
     List<Category> findAllByMemberIdAndNotDeleted(@Param("memberId") Long memberId);
 
     default Category findByIdOrThrow(Long categoryId) {
-        return findById(categoryId).orElseThrow(
+        return findByIdAndIsDeletedFalse(categoryId).orElseThrow(
                 () -> new NotFoundException(ErrorCode.NOT_FOUND_CATEGORY));
     }
 }

--- a/src/main/java/site/katchup/katchupserver/api/subTask/repository/SubTaskRepository.java
+++ b/src/main/java/site/katchup/katchupserver/api/subTask/repository/SubTaskRepository.java
@@ -1,7 +1,10 @@
 package site.katchup.katchupserver.api.subTask.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import site.katchup.katchupserver.api.category.domain.Category;
 import site.katchup.katchupserver.api.subTask.domain.SubTask;
 import site.katchup.katchupserver.api.task.domain.Task;
 import site.katchup.katchupserver.common.exception.NotFoundException;
@@ -12,7 +15,8 @@ import java.util.Optional;
 
 @Repository
 public interface SubTaskRepository extends JpaRepository<SubTask, Long> {
-    List<SubTask> findAllByTaskId(Long taskId);
+    @Query("select s from SubTask s where s.task.id = :taskId and s.isDeleted = false")
+    List<SubTask> findAllByTaskIdAndNotDeleted(@Param("taskId") Long taskId);
 
     Optional<SubTask> findSubTaskByTaskAndName(Task task, String name);
 

--- a/src/main/java/site/katchup/katchupserver/api/subTask/service/Impl/SubTaskServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/subTask/service/Impl/SubTaskServiceImpl.java
@@ -25,7 +25,7 @@ public class SubTaskServiceImpl implements SubTaskService {
     @Transactional(readOnly = true)
     public List<SubTaskGetResponseDto> getAllSubTask(Long taskId) {
 
-        return subTaskRepository.findAllByTaskId(taskId).stream()
+        return subTaskRepository.findAllByTaskIdAndNotDeleted(taskId).stream()
                 .map(subTask -> SubTaskGetResponseDto.of(subTask.getId(), subTask.getName()))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/site/katchup/katchupserver/api/task/controller/TaskController.java
+++ b/src/main/java/site/katchup/katchupserver/api/task/controller/TaskController.java
@@ -34,29 +34,16 @@ public class TaskController {
     private final CardService cardService;
     private final TaskService taskService;
 
-    @Operation(summary = "업무 목록 조회 API")
+    @Operation(summary = "카테고리 내의 업무 조회 API")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "업무 목록 조회 성공"),
-            @ApiResponse(responseCode = "400", description = "업무 목록 조회 성공", content = @Content),
-            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
-    })
-    @GetMapping()
-    @ResponseStatus(HttpStatus.OK)
-    public ApiResponseDto<List<TaskGetResponseDto>> getAllTask(Principal principal) {
-        Long memberId = MemberUtil.getMemberId(principal);
-        return ApiResponseDto.success(taskService.getAllTask(memberId));
-    }
-
-    @Operation(summary = "업무 조회 API")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "업무 조회 성공"),
-            @ApiResponse(responseCode = "400", description = "업무 조회 실패", content = @Content),
+            @ApiResponse(responseCode = "200", description = "카테고리 내의 업무 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "카테고리 내의 업무 조회 실패", content = @Content),
             @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     })
     @GetMapping("/categories/{categoryId}")
     @ResponseStatus(HttpStatus.OK)
     public ApiResponseDto<List<TaskGetResponseDto>> getByCategoryId(@PathVariable final Long categoryId) {
-        return ApiResponseDto.success(taskService.getByCategoryId(categoryId));
+        return ApiResponseDto.success(taskService.getAllByCategory(categoryId));
     }
 
     @Operation(summary = "업무 업데이트 API")
@@ -95,7 +82,7 @@ public class TaskController {
     })
     @GetMapping("/{taskId}/cards")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponseDto<List<CardListGetResponseDto>> getCardList(@PathVariable final Long taskId) {
+    public ApiResponseDto<List<CardListGetResponseDto>> getCardList(@PathVariable Long taskId) {
         return ApiResponseDto.success(cardService.getCardList(taskId));
     }
 

--- a/src/main/java/site/katchup/katchupserver/api/task/repository/TaskRepository.java
+++ b/src/main/java/site/katchup/katchupserver/api/task/repository/TaskRepository.java
@@ -1,19 +1,27 @@
 package site.katchup.katchupserver.api.task.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import site.katchup.katchupserver.api.category.domain.Category;
 import site.katchup.katchupserver.api.task.domain.Task;
 import site.katchup.katchupserver.common.exception.NotFoundException;
 import site.katchup.katchupserver.common.response.ErrorCode;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface TaskRepository extends JpaRepository<Task, Long> {
-    List<Task> findByCategoryId(Long categoryId);
+
+    Optional<Task> findByIdAndIsDeletedFalse(Long id);
 
     boolean existsByCategoryIdAndName(Long categoryId, String name);
 
+    @Query("select t from Task t where t.category.id = :categoryId and t.isDeleted = false")
+    List<Task> findAllByCategoryIdAndNotDeleted(@Param("categoryId") Long categoryId);
+
     default Task findByIdOrThrow(Long taskId) {
-        return findById(taskId).orElseThrow(
+        return findByIdAndIsDeletedFalse(taskId).orElseThrow(
                 () -> new NotFoundException(ErrorCode.NOT_FOUND_TASK));
     }
 }

--- a/src/main/java/site/katchup/katchupserver/api/task/service/Impl/TaskServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/task/service/Impl/TaskServiceImpl.java
@@ -28,17 +28,8 @@ public class TaskServiceImpl implements TaskService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<TaskGetResponseDto> getAllTask(Long memberId) {
-        return categoryRepository.findAllByMemberIdAndNotDeleted(memberId).stream()
-                .flatMap(category -> taskRepository.findByCategoryId(category.getId()).stream())
-                .map(task -> TaskGetResponseDto.of(task.getId(), task.getName()))
-                .collect(Collectors.toList());
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public List<TaskGetResponseDto> getByCategoryId(Long categoryId) {
-        return taskRepository.findByCategoryId(categoryId).stream()
+    public List<TaskGetResponseDto> getAllByCategory(Long categoryId) {
+        return taskRepository.findAllByCategoryIdAndNotDeleted(categoryId).stream()
                 .map(task -> TaskGetResponseDto.of(task.getId(), task.getName()))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/site/katchup/katchupserver/api/task/service/TaskService.java
+++ b/src/main/java/site/katchup/katchupserver/api/task/service/TaskService.java
@@ -9,8 +9,7 @@ import java.util.List;
 
 public interface TaskService {
 
-    List<TaskGetResponseDto> getAllTask(Long memberId);
-    List<TaskGetResponseDto> getByCategoryId(Long categoryId);
+    List<TaskGetResponseDto> getAllByCategory(Long categoryId);
     void updateTaskName(Long taskId, TaskUpdateRequestDto taskUpdateRequestDto);
     Long createTaskName(TaskCreateRequestDto taskCreateRequestDto);
     void deleteTask(Long taskId);


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
- 업무 카드 & 업무 삭제 로직 오류 수정

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 업무 삭제 시, 카테고리 내 업무 목록 조회 시 가져오지 않도록 수정했습니다.
- 삭제된 업무 아래의 업무 카드들 역시 조회 시 가져오지 않도록 수정했습니다.
- 업무 카드 삭제 시, 삭제한 업무 카드도 보이지 않도록 수정했습니다.

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #123 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
