### PR TITLE
[FEAT] 업무 카드 수정 API

### DIFF
--- a/src/main/java/site/katchup/katchupserver/api/card/controller/CardController.java
+++ b/src/main/java/site/katchup/katchupserver/api/card/controller/CardController.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import site.katchup.katchupserver.api.card.dto.request.CardCreateRequestDto;
 import site.katchup.katchupserver.api.card.dto.request.CardDeleteRequestDto;
+import site.katchup.katchupserver.api.card.dto.request.CardUpdateRequestDto;
 import site.katchup.katchupserver.api.card.dto.response.CardGetResponseDto;
 import site.katchup.katchupserver.api.card.service.CardService;
 import site.katchup.katchupserver.common.dto.ApiResponseDto;
@@ -63,6 +64,21 @@ public class CardController {
             })
     public ApiResponseDto deleteCards(@RequestBody final CardDeleteRequestDto cardDeleteRequestDto) {
         cardService.deleteCardList(cardDeleteRequestDto);
+        return ApiResponseDto.success();
+    }
+
+    @Operation(summary = "업무 카드 수정 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "업무 카드 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "업무 카드 수정 실패", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    })
+    @PatchMapping("/{cardId}")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto updateCard(Principal principal, @PathVariable Long cardId,
+                                     @Valid @RequestBody CardUpdateRequestDto cardUpdateRequestDto ) {
+        Long memberId = MemberUtil.getMemberId(principal);
+        cardService.updateCard(memberId, cardId, cardUpdateRequestDto);
         return ApiResponseDto.success();
     }
 }

--- a/src/main/java/site/katchup/katchupserver/api/card/domain/Card.java
+++ b/src/main/java/site/katchup/katchupserver/api/card/domain/Card.java
@@ -76,7 +76,8 @@ public class Card extends BaseEntity {
         this.placementOrder += 1;
     }
 
-    public void updateCard(String content, String note, SubTask subTask) {
+    public void updateCard(Long placementOrder, String content, String note, SubTask subTask) {
+        this.placementOrder = placementOrder;
         this.content = content;
         this.note = note;
         this.subTask = subTask;

--- a/src/main/java/site/katchup/katchupserver/api/card/domain/Card.java
+++ b/src/main/java/site/katchup/katchupserver/api/card/domain/Card.java
@@ -5,8 +5,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.katchup.katchupserver.api.file.domain.File;
+import site.katchup.katchupserver.api.file.dto.request.FileCreateRequestDto;
 import site.katchup.katchupserver.api.link.domain.Link;
 import site.katchup.katchupserver.api.screenshot.domain.Screenshot;
+import site.katchup.katchupserver.api.screenshot.dto.request.ScreenshotCreateRequestDto;
 import site.katchup.katchupserver.api.subTask.domain.SubTask;
 import site.katchup.katchupserver.common.domain.BaseEntity;
 
@@ -72,5 +74,12 @@ public class Card extends BaseEntity {
     
     public void plusPlacementOrder() {
         this.placementOrder += 1;
+    }
+
+    public void updateCard(String content, String note, SubTask subTask) {
+        this.content = content;
+        this.note = note;
+        this.subTask = subTask;
+        this.subTask.addCard(this);
     }
 }

--- a/src/main/java/site/katchup/katchupserver/api/card/dto/request/CardCreateRequestDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/card/dto/request/CardCreateRequestDto.java
@@ -7,7 +7,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import site.katchup.katchupserver.api.file.dto.request.FileCreateRequestDto;
 import site.katchup.katchupserver.api.screenshot.dto.request.ScreenshotCreateRequestDto;
-import site.katchup.katchupserver.api.sticker.dto.request.StickerCreateRequestDto;
 
 import java.util.List;
 

--- a/src/main/java/site/katchup/katchupserver/api/card/dto/request/CardUpdateRequestDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/card/dto/request/CardUpdateRequestDto.java
@@ -1,0 +1,37 @@
+package site.katchup.katchupserver.api.card.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import site.katchup.katchupserver.api.file.dto.request.FileCreateRequestDto;
+import site.katchup.katchupserver.api.screenshot.dto.request.ScreenshotCreateRequestDto;
+
+import java.util.List;
+
+@AllArgsConstructor(staticName = "of")
+@Getter
+public class CardUpdateRequestDto {
+    @NotNull(message = "CD-110")
+    private Long categoryId;
+
+    @NotNull(message = "CD-111")
+    private Long taskId;
+
+    @Schema(description = "세부 업무 작성 안할 시, 해당 값 0으로")
+    @NotNull(message = "CD-112")
+    private Long subTaskId;
+
+    @NotNull(message = "CD-113")
+    private List<Long> keywordIdList;
+
+    private List<ScreenshotCreateRequestDto> screenshotList;
+
+    private List<FileCreateRequestDto> fileList;
+
+    private String note;
+
+    @NotBlank(message = "CD-114")
+    private String content;
+}

--- a/src/main/java/site/katchup/katchupserver/api/card/service/CardService.java
+++ b/src/main/java/site/katchup/katchupserver/api/card/service/CardService.java
@@ -3,6 +3,7 @@ package site.katchup.katchupserver.api.card.service;
 import org.springframework.transaction.annotation.Transactional;
 import site.katchup.katchupserver.api.card.dto.request.CardCreateRequestDto;
 import site.katchup.katchupserver.api.card.dto.request.CardDeleteRequestDto;
+import site.katchup.katchupserver.api.card.dto.request.CardUpdateRequestDto;
 import site.katchup.katchupserver.api.card.dto.response.CardGetResponseDto;
 import site.katchup.katchupserver.api.card.dto.response.CardListGetResponseDto;
 
@@ -15,5 +16,6 @@ public interface CardService {
     CardGetResponseDto getCard(Long cardId);
     void deleteCardList(CardDeleteRequestDto cardDeleteRequestDto);
     void createCard(Long memberId, CardCreateRequestDto cardCreateRequestDto);
+    void updateCard(Long memberId, Long cardId, CardUpdateRequestDto cardUpdateRequestDto);
 
 }

--- a/src/main/java/site/katchup/katchupserver/api/card/service/Impl/CardServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/card/service/Impl/CardServiceImpl.java
@@ -37,6 +37,8 @@ import site.katchup.katchupserver.api.task.domain.Task;
 import site.katchup.katchupserver.api.task.repository.TaskRepository;
 import site.katchup.katchupserver.api.trash.domain.Trash;
 import site.katchup.katchupserver.api.trash.repository.TrashRepository;
+import site.katchup.katchupserver.common.exception.BadRequestException;
+import site.katchup.katchupserver.common.response.ErrorCode;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -167,24 +169,24 @@ public class CardServiceImpl implements CardService {
         }
 
         Card card = cardRepository.findByIdOrThrow(cardId);
-        card.updateCard(requestDto.getContent(), requestDto.getNote(),subTask);
+        card.updateCard(getPlacementOrder(subTask), requestDto.getContent(), requestDto.getNote(), subTask);
 
         List<CardKeyword> cardKeyword = cardKeywordRepository.findAllByCardId(cardId);
 
-        int count = 0;
+        boolean flag = true;
         for (Long keywordId : requestDto.getKeywordIdList()) {
             for (CardKeyword cardKeywords : cardKeyword) {
                 if (Objects.equals(cardKeywords.getKeyword().getId(), keywordId)) {
-                    count += 1;
+                    flag = false;
                 }
             }
-            if (count == 0) {
+            if (flag) {
                 cardKeywordRepository.save(CardKeyword.builder()
                         .card(card)
                         .keyword(keywordRepository.findByIdOrThrow(keywordId))
                         .build());
             }
-            count = 0;
+            flag = true;
         }
 
         for (ScreenshotCreateRequestDto screenshotInfo : requestDto.getScreenshotList()) {

--- a/src/main/java/site/katchup/katchupserver/api/card/service/Impl/CardServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/card/service/Impl/CardServiceImpl.java
@@ -171,22 +171,15 @@ public class CardServiceImpl implements CardService {
         Card card = cardRepository.findByIdOrThrow(cardId);
         card.updateCard(getPlacementOrder(subTask), requestDto.getContent(), requestDto.getNote(), subTask);
 
-        List<CardKeyword> cardKeyword = cardKeywordRepository.findAllByCardId(cardId);
+        List<CardKeyword> cardKeywordList = cardKeywordRepository.findAllByCardId(cardId);
+        cardKeywordRepository.deleteAll(cardKeywordList);
 
-        boolean flag = true;
         for (Long keywordId : requestDto.getKeywordIdList()) {
-            for (CardKeyword cardKeywords : cardKeyword) {
-                if (Objects.equals(cardKeywords.getKeyword().getId(), keywordId)) {
-                    flag = false;
-                }
-            }
-            if (flag) {
-                cardKeywordRepository.save(CardKeyword.builder()
-                        .card(card)
-                        .keyword(keywordRepository.findByIdOrThrow(keywordId))
-                        .build());
-            }
-            flag = true;
+            CardKeyword cardKeyword = CardKeyword.builder()
+                    .card(card)
+                    .keyword(keywordRepository.findByIdOrThrow(keywordId))
+                    .build();
+            cardKeywordRepository.save(cardKeyword);
         }
 
         for (ScreenshotCreateRequestDto screenshotInfo : requestDto.getScreenshotList()) {

--- a/src/main/java/site/katchup/katchupserver/api/keyword/domain/CardKeyword.java
+++ b/src/main/java/site/katchup/katchupserver/api/keyword/domain/CardKeyword.java
@@ -5,6 +5,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.katchup.katchupserver.api.card.domain.Card;
+import site.katchup.katchupserver.api.file.dto.request.FileCreateRequestDto;
+import site.katchup.katchupserver.api.screenshot.dto.request.ScreenshotCreateRequestDto;
+
+import java.util.List;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.*;

--- a/src/main/java/site/katchup/katchupserver/api/keyword/domain/CardKeyword.java
+++ b/src/main/java/site/katchup/katchupserver/api/keyword/domain/CardKeyword.java
@@ -5,10 +5,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.katchup.katchupserver.api.card.domain.Card;
-import site.katchup.katchupserver.api.file.dto.request.FileCreateRequestDto;
-import site.katchup.katchupserver.api.screenshot.dto.request.ScreenshotCreateRequestDto;
-
-import java.util.List;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.*;

--- a/src/main/java/site/katchup/katchupserver/api/keyword/repository/CardKeywordRepository.java
+++ b/src/main/java/site/katchup/katchupserver/api/keyword/repository/CardKeywordRepository.java
@@ -8,5 +8,4 @@ import java.util.List;
 
 public interface CardKeywordRepository extends JpaRepository<CardKeyword, Long> {
     List<CardKeyword> findAllByCardId(Long cardId);
-
 }

--- a/src/main/java/site/katchup/katchupserver/api/keyword/repository/CardKeywordRepository.java
+++ b/src/main/java/site/katchup/katchupserver/api/keyword/repository/CardKeywordRepository.java
@@ -2,7 +2,6 @@ package site.katchup.katchupserver.api.keyword.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import site.katchup.katchupserver.api.keyword.domain.CardKeyword;
-import site.katchup.katchupserver.api.keyword.domain.Keyword;
 
 import java.util.List;
 


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
업무 카드 수정 API를 구현하였습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
1. 키워드 수정 시, **CardKeyword DB에 있는 기존 정보 다 날리고 다시 저장** (중복 저장 방지 위함)
2. **업데이트하지 않는 스크린샷, 파일의 key 값이 달라지면 안되므로  전부 다시 저장** (UUID를 id값으로 사용하므로 중복저장되지 않음)
3. **변경된 subTaskId 고려하여 placementOrder, note, content, subTask 업데이트는 카드 update 함수 이용**
4. 업무 카드 생성 시와 **같은 Custom Code를 사용하므로 노션에 명칭을 변경**해두었습니다. 
    - EX) _업무 카드 생성 시, 카테고리 id는 필수 값입니다. -> 업무 카드 생성(수정) 시, 카테고리 id는 필수 값입니다._
![15](https://github.com/Katchup-dev/Katchup-server/assets/64405757/3efc48e0-a227-4949-b5a2-82e52ac7fdb0)

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #127 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
