### PR TITLE
[FIX] 업무 카드 생성 전, 파일 및 스크린샷 삭제 로직 수정

### DIFF
--- a/src/main/java/site/katchup/katchupserver/api/card/controller/CardController.java
+++ b/src/main/java/site/katchup/katchupserver/api/card/controller/CardController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -35,9 +36,10 @@ public class CardController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponseDto createCard(Principal principal,
-            @Valid @RequestBody CardCreateRequestDto cardCreateRequestDto ) {
+                                     @Valid @RequestBody CardCreateRequestDto cardCreateRequestDto, HttpServletResponse response) {
         Long memberId = MemberUtil.getMemberId(principal);
-        cardService.createCard(memberId, cardCreateRequestDto);
+        Long cardId = cardService.createCard(memberId, cardCreateRequestDto);
+        response.addHeader("Location", String.valueOf(cardId));
         return ApiResponseDto.success();
     }
 

--- a/src/main/java/site/katchup/katchupserver/api/card/dto/response/CardListGetResponseDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/card/dto/response/CardListGetResponseDto.java
@@ -22,9 +22,11 @@ public class CardListGetResponseDto {
     private List<KeywordGetResponseDto> keywordList = new ArrayList<>();
     private String content;
     private Boolean existFile;
+    private Boolean existScreenshot;
 
     public static CardListGetResponseDto of (Card card, SubTask subTask, List<KeywordGetResponseDto> keywordList) {
         Boolean existFile = card.getFiles().isEmpty() ? false : true;
+        Boolean existScreenshot = card.getScreenshots().isEmpty() ? false : true;
         return CardListGetResponseDto.builder()
                 .cardId(card.getId())
                 .subTaskId(subTask.getId())
@@ -33,6 +35,7 @@ public class CardListGetResponseDto {
                 .keywordList(keywordList)
                 .content(card.getContent())
                 .existFile(existFile)
+                .existScreenshot(existScreenshot)
                 .build();
     }
 }

--- a/src/main/java/site/katchup/katchupserver/api/card/service/CardService.java
+++ b/src/main/java/site/katchup/katchupserver/api/card/service/CardService.java
@@ -15,7 +15,7 @@ public interface CardService {
     List<CardListGetResponseDto> getCardList(Long taskId);
     CardGetResponseDto getCard(Long cardId);
     void deleteCardList(CardDeleteRequestDto cardDeleteRequestDto);
-    void createCard(Long memberId, CardCreateRequestDto cardCreateRequestDto);
+    Long createCard(Long memberId, CardCreateRequestDto cardCreateRequestDto);
     void updateCard(Long memberId, Long cardId, CardUpdateRequestDto cardUpdateRequestDto);
 
 }

--- a/src/main/java/site/katchup/katchupserver/api/card/service/Impl/CardServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/card/service/Impl/CardServiceImpl.java
@@ -95,7 +95,7 @@ public class CardServiceImpl implements CardService {
 
     @Override
     @Transactional
-    public void createCard(Long memberId, CardCreateRequestDto requestDto) {
+    public Long createCard(Long memberId, CardCreateRequestDto requestDto) {
 
         SubTask subTask;
         if (requestDto.getSubTaskId() == SUB_TASK_ETC_ID) {
@@ -154,6 +154,8 @@ public class CardServiceImpl implements CardService {
 
             fileRepository.save(newFile);
         }
+
+        return savedCard.getId();
     }
 
     @Override

--- a/src/main/java/site/katchup/katchupserver/api/card/service/Impl/CardServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/card/service/Impl/CardServiceImpl.java
@@ -125,7 +125,8 @@ public class CardServiceImpl implements CardService {
         for (ScreenshotCreateRequestDto screenshotInfo : requestDto.getScreenshotList()) {
             Screenshot newScreenshot = Screenshot.builder()
                     .id(screenshotInfo.getScreenshotUUID())
-                    .screenshotKey(screenshotService.createKey(memberId, screenshotInfo))
+                    .screenshotKey(screenshotService.createKey(memberId, screenshotInfo.getScreenshotUploadDate(), screenshotInfo.getScreenshotUUID().toString(),
+                            screenshotInfo.getScreenshotName()))
                     .url(screenshotService.findUrl(memberId, screenshotInfo))
                     .card(savedCard)
                     .build();
@@ -146,8 +147,10 @@ public class CardServiceImpl implements CardService {
         for (FileCreateRequestDto fileInfo : requestDto.getFileList()) {
             File newFile = File.builder()
                     .id(fileInfo.getFileUUID())
-                    .fileKey(fileService.createKey(memberId, fileInfo))
-                    .name(fileInfo.getFileName())
+                    .fileKey(fileService.createKey(memberId, fileInfo.getFileUploadDate(), fileInfo.getFileUUID().toString()
+                    , fileInfo.getFileOriginalName()))
+                    .originalName(fileInfo.getFileOriginalName())
+                    .changedName(fileInfo.getFileChangedName())
                     .size(fileInfo.getSize())
                     .card(savedCard)
                     .build();
@@ -187,7 +190,8 @@ public class CardServiceImpl implements CardService {
         for (ScreenshotCreateRequestDto screenshotInfo : requestDto.getScreenshotList()) {
             Screenshot newScreenshot = Screenshot.builder()
                     .id(screenshotInfo.getScreenshotUUID())
-                    .screenshotKey(screenshotService.createKey(memberId, screenshotInfo))
+                    .screenshotKey(screenshotService.createKey(memberId, screenshotInfo.getScreenshotUploadDate(), screenshotInfo.getScreenshotUUID().toString(),
+                            screenshotInfo.getScreenshotName()))
                     .url(screenshotService.findUrl(memberId, screenshotInfo))
                     .card(card)
                     .build();
@@ -198,8 +202,10 @@ public class CardServiceImpl implements CardService {
         for (FileCreateRequestDto fileInfo : requestDto.getFileList()) {
             File newFile = File.builder()
                     .id(fileInfo.getFileUUID())
-                    .fileKey(fileService.createKey(memberId, fileInfo))
-                    .name(fileInfo.getFileName())
+                    .fileKey(fileService.createKey(memberId, fileInfo.getFileUploadDate(), fileInfo.getFileUUID().toString()
+                    , fileInfo.getFileOriginalName()))
+                    .originalName(fileInfo.getFileOriginalName())
+                    .changedName(fileInfo.getFileChangedName())
                     .size(fileInfo.getSize())
                     .card(card)
                     .build();
@@ -262,7 +268,7 @@ public class CardServiceImpl implements CardService {
 
     private List<FileGetResponseDto> getFileDtoList(Long cardId) {
         return cardRepository.findByIdOrThrow(cardId).getFiles().stream()
-                .map(file -> FileGetResponseDto.of(file.getId(), file.getName(), file.getSize()))
+                .map(file -> FileGetResponseDto.of(file.getId(), file.getOriginalName(), file.getChangedName(), file.getSize()))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/site/katchup/katchupserver/api/file/controller/FileController.java
+++ b/src/main/java/site/katchup/katchupserver/api/file/controller/FileController.java
@@ -46,10 +46,12 @@ public class FileController {
             @ApiResponse(responseCode = "400", description = "파일 삭제 실패", content = @Content),
             @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     })
-    @DeleteMapping("/files/{fileId}")
+    @DeleteMapping("/files")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponseDto delete(@PathVariable String fileId) {
-        fileService.deleteFile(fileId);
+    public ApiResponseDto delete(Principal principal, @RequestParam(value = "fileOriginalName") String fileOriginalName
+            , @RequestParam(value = "fileUploadDate") String fileUploadDate, @RequestParam(value = "fileUUID") String fileUUID) {
+        Long memberId = MemberUtil.getMemberId(principal);
+        fileService.deleteFile(memberId, fileOriginalName, fileUploadDate, fileUUID);
         return success();
     }
 

--- a/src/main/java/site/katchup/katchupserver/api/file/domain/File.java
+++ b/src/main/java/site/katchup/katchupserver/api/file/domain/File.java
@@ -21,7 +21,10 @@ public class File extends BaseEntity {
     private UUID id;
 
     @Column(nullable = false)
-    private String name;
+    private String originalName;
+
+    @Column(nullable = false)
+    private String changedName;
 
     @Column(nullable = false, name = "file_key")
     private String fileKey;
@@ -34,9 +37,10 @@ public class File extends BaseEntity {
     private Card card;
 
     @Builder
-    public File(UUID id, String name, String fileKey, int size, Card card) {
+    public File(UUID id, String originalName, String changedName, String fileKey, int size, Card card) {
         this.id = id;
-        this.name = name;
+        this.originalName = originalName;
+        this.changedName = changedName;
         this.fileKey = fileKey;
         this.card = card;
         this.size = size;

--- a/src/main/java/site/katchup/katchupserver/api/file/dto/request/FileCreateRequestDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/file/dto/request/FileCreateRequestDto.java
@@ -16,9 +16,13 @@ public class FileCreateRequestDto {
     @NotNull
     private UUID fileUUID;
 
-    @Schema(description = "파일 이름", example = "와이어프레임 및 드라이브 사용법.pdf")
+    @Schema(description = "파일 원본 이름", example = "와이어프레임 및 드라이브 사용법.pdf")
     @NotNull
-    private String fileName;
+    private String fileOriginalName;
+
+    @Schema(description = "파일 변경된 이름", example = "카테고리_업무_세부업무_와이어프레임 사용법.pdf")
+    @NotNull
+    private String fileChangedName;
 
     @Schema(description = "파일 업로드 일자", example = "2023/08/23")
     @NotNull

--- a/src/main/java/site/katchup/katchupserver/api/file/dto/response/FileGetResponseDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/file/dto/response/FileGetResponseDto.java
@@ -13,8 +13,11 @@ public class FileGetResponseDto {
     @Schema(description = "파일 고유 id", example = "ddwd-wdwd-wdwd-wdwdwdwd")
     private UUID id;
 
-    @Schema(description = "파일 이름", example = "와이어프레임 및 드라이브 사용법.pdf")
-    private String name;
+    @Schema(description = "파일 원본 이름", example = "와이어프레임 및 드라이브 사용법.pdf")
+    private String originalName;
+
+    @Schema(description = "파일 변경된 이름", example = "카테고리_업무_세부업무_와이어프레임 사용법.pdf")
+    private String changedName;
 
     @Schema(description = "파일 사이즈 (KB 단위로 저장)", example = "189277")
     private int size;

--- a/src/main/java/site/katchup/katchupserver/api/file/repository/FileRepository.java
+++ b/src/main/java/site/katchup/katchupserver/api/file/repository/FileRepository.java
@@ -17,4 +17,5 @@ public interface FileRepository extends JpaRepository<File, UUID> {
         return findById(uuid).orElseThrow(
                 () -> new NotFoundException(ErrorCode.NOT_FOUND_FILE));
     }
+
 }

--- a/src/main/java/site/katchup/katchupserver/api/file/service/FileService.java
+++ b/src/main/java/site/katchup/katchupserver/api/file/service/FileService.java
@@ -9,9 +9,9 @@ public interface FileService {
 
     FileGetDownloadPreSignedResponseDto getDownloadPreSignedUrl(String filePath, String fileName);
 
-    String createKey(Long memberId, FileCreateRequestDto requestDto);
+    String createKey(Long memberId, String fileDate, String fileUUID, String fileName);
 
-    void deleteFile(String fileId);
+    void deleteFile(Long memberId, String fileOriginalName, String fileUploadDate, String fileUUID);
 
     FileGetUploadPreSignedResponseDto getUploadPreSignedUrl(Long memberId, String fileName);
 

--- a/src/main/java/site/katchup/katchupserver/api/screenshot/controller/ScreenshotController.java
+++ b/src/main/java/site/katchup/katchupserver/api/screenshot/controller/ScreenshotController.java
@@ -46,10 +46,12 @@ public class ScreenshotController {
                     @ApiResponse(responseCode = "400", description = "스크린샷 삭제 실패", content = @Content),
                     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
             })
-    @DeleteMapping("/screenshots/{screenshotId}")
+    @DeleteMapping("/screenshots")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponseDto deleteScreenshot(@PathVariable String screenshotId) {
-        screenshotService.delete(screenshotId);
+    public ApiResponseDto delete(Principal principal, @RequestParam(value = "screenshotName") String screenshotName
+            , @RequestParam(value = "screenshotUploadDate") String screenshotUploadDate, @RequestParam(value = "screenshotUUID") String screenshotUUID) {
+        Long memberId = MemberUtil.getMemberId(principal);
+        screenshotService.deleteFile(memberId, screenshotName, screenshotUploadDate, screenshotUUID);
         return success();
     }
 

--- a/src/main/java/site/katchup/katchupserver/api/screenshot/service/ScreenshotService.java
+++ b/src/main/java/site/katchup/katchupserver/api/screenshot/service/ScreenshotService.java
@@ -8,10 +8,9 @@ public interface ScreenshotService {
 
     ScreenshotGetPreSignedResponseDto getPreSignedUrl(Long memberId, String screenshotName);
 
-    @Transactional
-    String createKey(Long memberId, ScreenshotCreateRequestDto requestDto);
+    String createKey(Long memberId, String screenshotDate, String screenshotUUID, String screenshotName);
 
-    void delete(String screenshotId);
+    void deleteFile(Long memberId, String screenshotName, String screenshotUploadDate, String screenshotUUID);
     String findUrl(Long memberId, ScreenshotCreateRequestDto requestDto);
 
 }


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
- 업무 카드 생성 전, 파일 및 스크린샷 삭제 로직 수정

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 업무 카드 생성 전, 파일 및 스크린샷 삭제 로직 수정했습니다.
- 업무 카드 생성 시, response header에 업무 카드 id 넣어서 내려드리도록 수정했습니다.
- 업무 내 업무 카드 목록 조회 api에서 스크린샷 유무 값도 내려드리도록 수정했습니다.

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #130 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
