### PR TITLE
[FIX] 파일 다운로드 시, 공백 그대로 유지

### DIFF
--- a/src/main/java/site/katchup/katchupserver/common/util/S3Util.java
+++ b/src/main/java/site/katchup/katchupserver/common/util/S3Util.java
@@ -54,11 +54,12 @@ public class S3Util {
     public String getDownloadPreSignedUrl(String filePath, String fileName) {
         try {
             String encodedFileName = URLEncoder.encode(fileName, "UTF-8");
+            String replacedFileName = encodedFileName.replaceAll("\\+", "%20");
 
             GeneratePresignedUrlRequest generatePresignedUrlRequest =
                     new GeneratePresignedUrlRequest(bucket, filePath)
                             .withMethod(HttpMethod.GET) // HTTP GET 요청
-                            .withResponseHeaders(new ResponseHeaderOverrides().withContentDisposition("attachment; filename=\"" + encodedFileName + "\""))
+                            .withResponseHeaders(new ResponseHeaderOverrides().withContentDisposition("attachment; filename=\"" + replacedFileName + "\""))
                             .withExpiration(getPreSignedUrlExpiration());
 
             return amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
파일 다운로드 시, 파일 이름 사이에 있는 공백이 +로 대체되는 이슈가 있어서 공백 그대로 유지하도록 해결하였습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
공백 유지 확인 완료했습니다.
![112](https://github.com/Katchup-dev/Katchup-server/assets/64405757/b3809d18-2c10-45b0-96f6-c3b80d136457)


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #132 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
