### PR TITLE
[FIX] 업무 카드 상세 조회 시, content와 note 값 누락된 버그 수정

### DIFF
--- a/src/main/java/site/katchup/katchupserver/api/card/dto/response/CardGetResponseDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/card/dto/response/CardGetResponseDto.java
@@ -16,6 +16,8 @@ public class CardGetResponseDto {
     private String category;
     private String task;
     private String subTask;
+    private String content;
+    private String note;
     private List<KeywordGetResponseDto> keywordList;
     private List<ScreenshotGetResponseDto> screenshotList;
     private List<FileGetResponseDto> fileList;

--- a/src/main/java/site/katchup/katchupserver/api/card/service/Impl/CardServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/card/service/Impl/CardServiceImpl.java
@@ -224,7 +224,7 @@ public class CardServiceImpl implements CardService {
         List<FileGetResponseDto> fileGetResponseDTOList = getFileDtoList(cardId);
         List<ScreenshotGetResponseDto> screenshotResponseDtoList = getScreenshotDtoList(cardId);
 
-        return CardGetResponseDto.of(card.getId(), category.getName(), task.getName(), card.getSubTask().getName(), keywordResponseDtoList, screenshotResponseDtoList, fileGetResponseDTOList);
+        return CardGetResponseDto.of(card.getId(), category.getName(), task.getName(), card.getSubTask().getName(), card.getContent(), card.getNote(), keywordResponseDtoList, screenshotResponseDtoList, fileGetResponseDTOList);
     }
 
     private Long getPlacementOrder(SubTask subTask) {


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
- 업무 카드 상세 조회 시, content와 note 값 누락된 버그 수정

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 업무 카드 상세 조회 시, content와 note 값 누락된 버그 수정 했습니다.

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #133 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
