### PR TITLE
[FIX] 업무 카드 조회 시 id 값들도 내려주도록 수정

### DIFF
--- a/src/main/java/site/katchup/katchupserver/api/card/dto/response/CardGetResponseDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/card/dto/response/CardGetResponseDto.java
@@ -13,9 +13,12 @@ import java.util.List;
 @AllArgsConstructor(staticName = "of")
 public class CardGetResponseDto {
     private Long cardId;
-    private String category;
-    private String task;
-    private String subTask;
+    private Long categoryId;
+    private String categoryName;
+    private Long taskId;
+    private String taskName;
+    private Long subTaskId;
+    private String subTaskName;
     private String content;
     private String note;
     private List<KeywordGetResponseDto> keywordList;

--- a/src/main/java/site/katchup/katchupserver/api/card/service/Impl/CardServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/card/service/Impl/CardServiceImpl.java
@@ -228,7 +228,8 @@ public class CardServiceImpl implements CardService {
         List<FileGetResponseDto> fileGetResponseDTOList = getFileDtoList(cardId);
         List<ScreenshotGetResponseDto> screenshotResponseDtoList = getScreenshotDtoList(cardId);
 
-        return CardGetResponseDto.of(card.getId(), category.getName(), task.getName(), card.getSubTask().getName(), card.getContent(), card.getNote(), keywordResponseDtoList, screenshotResponseDtoList, fileGetResponseDTOList);
+        return CardGetResponseDto.of(card.getId(), category.getId(), category.getName(),
+                task.getId(), task.getName(), card.getSubTask().getId(), card.getSubTask().getName(), card.getContent(), card.getNote(), keywordResponseDtoList, screenshotResponseDtoList, fileGetResponseDTOList);
     }
 
     private Long getPlacementOrder(SubTask subTask) {


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
- 업무 카드 조회 시 id 값들도 내려주도록 수정

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 업무 카드 수정 시에 카테고리, 업무, 세부 업무 id를 넘겨줘야 하므로 업무 카드 상세 조회 시 해당 값들을 내려주도록 수정했습니다.

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
