### PR TITLE
[FIX] 토큰 재발급 API

### DIFF
--- a/src/main/java/site/katchup/katchupserver/api/member/repository/MemberRepository.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/repository/MemberRepository.java
@@ -9,9 +9,8 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
+    Optional<Member> findByRefreshToken(String refreshToken);
     boolean existsByEmail(String email);
-
-    boolean existsByIdAndRefreshToken(Long id, String refreshToken);
 
     default Member findByEmailOrThrow(String email) {
         return findByEmail(email)
@@ -22,4 +21,10 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
         return findById(memberId)
                 .orElseThrow(() -> new UnauthorizedException(ErrorCode.INVALID_MEMBER));
     }
+
+    default Member findByRefreshTokenOrThrow(String refreshToken) {
+        return findByRefreshToken(refreshToken)
+                .orElseThrow(() -> new UnauthorizedException(ErrorCode.INVALID_MEMBER));
+    }
+
 }

--- a/src/main/java/site/katchup/katchupserver/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/site/katchup/katchupserver/config/jwt/JwtAuthenticationFilter.java
@@ -40,9 +40,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                         return;
                     } else if (jwtTokenProvider.validateToken(refreshToken) == JwtExceptionType.VALID_JWT_TOKEN) {
                         // 토큰 재발급
-                        Long memberId = jwtTokenProvider.validateMemberRefreshToken(accessToken, refreshToken);
+                        Long memberId = jwtTokenProvider.validateMemberRefreshToken(refreshToken);
                         Authentication authentication = new UserAuthentication(memberId, null, null);
-
                         String newAccessToken = jwtTokenProvider.generateAccessToken(authentication);
 
                         setAuthentication(newAccessToken);

--- a/src/main/java/site/katchup/katchupserver/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/site/katchup/katchupserver/config/jwt/JwtTokenProvider.java
@@ -9,9 +9,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
+import site.katchup.katchupserver.api.member.domain.Member;
 import site.katchup.katchupserver.api.member.repository.MemberRepository;
-import site.katchup.katchupserver.common.exception.UnauthorizedException;
-import site.katchup.katchupserver.common.response.ErrorCode;
 
 import java.security.Key;
 import java.util.Date;
@@ -112,12 +111,8 @@ public class JwtTokenProvider {
         return Keys.hmacShaKeyFor(keyBytes);
     }
 
-    public Long validateMemberRefreshToken(String accessToken, String refreshToken) {
-        Claims claims = getAccessTokenPayload(accessToken);
-        Long memberId = Long.valueOf(String.valueOf(claims.get("memberId")));
-        if (!memberRepository.existsByIdAndRefreshToken(memberId, refreshToken)) {
-            throw new UnauthorizedException(ErrorCode.INVALID_MEMBER);
-        }
-        return memberId;
+    public Long validateMemberRefreshToken(String refreshToken) {
+        Member member = memberRepository.findByRefreshTokenOrThrow(refreshToken);
+        return member.getId();
     }
 }


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
Security 코드 개선 후, 토큰 재발급 API 작동하지 않는 이슈 해결


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
토큰 재발급 로직 상, accessToken이 만료되고 refreshToken이 만료되지 않은 경우에만 재발급을 해줍니다.
accessToken이 만료된 후에는 Claim 객체 안에 아무런 정보가 없어 해당 멤버에 대한 토큰 재발급이 불가합니다.
따라서 accessToken이 만료되었을 경우, DB 안에 저장된 refreshToken을 기반으로 해당 멤버를 찾아 accessToken을 재발급하는 방향으로 수정하였습니다.

![22](https://github.com/Katchup-dev/Katchup-server/assets/64405757/40ba70d9-b20c-481a-bd31-3cbf810974dd)



## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #140 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
