### PR TITLE
[RENAME] 업무카드 수정 시 request의 필드명과 업무카드 조회 시 response의 필드명 통일

### DIFF
--- a/src/main/java/site/katchup/katchupserver/api/file/dto/response/FileGetResponseDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/file/dto/response/FileGetResponseDto.java
@@ -1,7 +1,6 @@
 package site.katchup.katchupserver.api.file.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -11,16 +10,16 @@ import java.util.UUID;
 @AllArgsConstructor(staticName = "of")
 public class FileGetResponseDto {
     @Schema(description = "파일 고유 id", example = "ddwd-wdwd-wdwd-wdwdwdwd")
-    private UUID id;
+    private UUID fileUUID;
 
     @Schema(description = "파일 원본 이름", example = "와이어프레임 및 드라이브 사용법.pdf")
-    private String originalName;
+    private String fileOriginalName;
 
     @Schema(description = "파일 변경된 이름", example = "카테고리_업무_세부업무_와이어프레임 사용법.pdf")
-    private String changedName;
+    private String fileChangedName;
 
     @Schema(description = "파일 업로드 일자", example = "2023/08/23")
-    private String uploadDate;
+    private String fileUploadDate;
 
     @Schema(description = "파일 사이즈 (KB 단위로 저장)", example = "189277")
     private int size;

--- a/src/main/java/site/katchup/katchupserver/api/screenshot/dto/response/ScreenshotGetResponseDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/screenshot/dto/response/ScreenshotGetResponseDto.java
@@ -3,7 +3,6 @@ package site.katchup.katchupserver.api.screenshot.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import site.katchup.katchupserver.api.sticker.domain.Sticker;
 import site.katchup.katchupserver.api.sticker.dto.response.StickerGetResponseDto;
 
 import java.util.List;
@@ -13,13 +12,13 @@ import java.util.UUID;
 @AllArgsConstructor(staticName = "of")
 public class ScreenshotGetResponseDto {
     @Schema(description = "스크린샷 고유 id", example = "ddwd-wdwd-wdwd-wdwdwdwd")
-    private UUID id;
+    private UUID screenshotUUID;
 
     @Schema(description = "스크린샷 url", example = "https://abde.s3.ap-northeast-2.amazonaws.com/1.png")
-    private String url;
+    private String screenshotUrl;
 
     @Schema(description = "스크린샷 업로드 일자", example = "2023/08/23")
-    private String uploadDate;
+    private String screenshotUploadDate;
 
     @Schema(description = "번호 스티커")
     private List<StickerGetResponseDto> stickerList;


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
필드명 통일

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
업무 카드 수정 시 request body의 필드명과 업무 카드 조회 시 response body의 필드명이 달라 클라 요청에 따라 이를 통일시켰습니다.
id -> fileUUID 이런 식으로 변경
![스키리ㅣ](https://github.com/Katchup-dev/Katchup-server/assets/64405757/a947d450-ecbb-4e2f-8fbd-c9d0ed39bacc)


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #153 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
