### PR TITLE
[FEAT] 회원 탈퇴 API

### DIFF
--- a/src/main/java/site/katchup/katchupserver/api/auth/service/Impl/AuthServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/auth/service/Impl/AuthServiceImpl.java
@@ -46,9 +46,9 @@ public class AuthServiceImpl implements AuthService {
 
             memberRepository.save(member);
         }
-        else memberRepository.findByEmailOrThrow(email).updateMemberStatus(false, refreshToken);
+        // 탈퇴한 유저가 회원가입한 경우, 이미 가입한 유저의 경우
+        else memberRepository.findByEmailOrThrow(email).updateMemberStatus(memberRepository.findByEmailOrThrow(email).isDeleted(), false, refreshToken);
 
-        // 등록된 유저 찾기
         Member signedMember = memberRepository.findByEmailOrThrow(email);
 
         Authentication authentication = new UserAuthentication(signedMember.getId(), null, null);

--- a/src/main/java/site/katchup/katchupserver/api/card/service/Impl/CardServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/card/service/Impl/CardServiceImpl.java
@@ -37,8 +37,6 @@ import site.katchup.katchupserver.api.task.domain.Task;
 import site.katchup.katchupserver.api.task.repository.TaskRepository;
 import site.katchup.katchupserver.api.trash.domain.Trash;
 import site.katchup.katchupserver.api.trash.repository.TrashRepository;
-import site.katchup.katchupserver.common.exception.BadRequestException;
-import site.katchup.katchupserver.common.response.ErrorCode;
 
 import java.util.*;
 import java.util.stream.Collectors;

--- a/src/main/java/site/katchup/katchupserver/api/category/repository/CategoryRepository.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/repository/CategoryRepository.java
@@ -21,6 +21,8 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     @Query("select c from Category c where c.member.id = :memberId and c.isDeleted = false")
     List<Category> findAllByMemberIdAndNotDeleted(@Param("memberId") Long memberId);
 
+    List<Category> findAllByMemberId(Long memberId);
+
     default Category findByIdOrThrow(Long categoryId) {
         return findByIdAndIsDeletedFalse(categoryId).orElseThrow(
                 () -> new NotFoundException(ErrorCode.NOT_FOUND_CATEGORY));

--- a/src/main/java/site/katchup/katchupserver/api/member/controller/MemberController.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/controller/MemberController.java
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-import site.katchup.katchupserver.api.member.dto.MemberProfileGetResponseDto;
+import site.katchup.katchupserver.api.member.dto.response.MemberProfileGetResponseDto;
 import site.katchup.katchupserver.api.member.service.MemberService;
 import site.katchup.katchupserver.common.dto.ApiResponseDto;
 import site.katchup.katchupserver.common.util.MemberUtil;

--- a/src/main/java/site/katchup/katchupserver/api/member/controller/WithdrawController.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/controller/WithdrawController.java
@@ -1,0 +1,38 @@
+package site.katchup.katchupserver.api.member.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import site.katchup.katchupserver.api.member.dto.request.MemberDeleteRequestDto;
+import site.katchup.katchupserver.api.member.service.WithdrawService;
+import site.katchup.katchupserver.common.dto.ApiResponseDto;
+import site.katchup.katchupserver.common.util.MemberUtil;
+
+import java.security.Principal;
+
+@RestController
+@RequestMapping("/api/v1/members")
+@RequiredArgsConstructor
+@Tag(name = "[Member] 회원 탈퇴 관련 API (V1)")
+public class WithdrawController {
+    private final WithdrawService withdrawService;
+
+    @Operation(summary = "회원 탈퇴 API")
+    @DeleteMapping()
+    @ResponseStatus(HttpStatus.OK)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공"),
+            @ApiResponse(responseCode = "400", description = "회원 탈퇴 실패", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    })
+    public ApiResponseDto deleteMember(Principal principal, @RequestBody final MemberDeleteRequestDto memberDeleteRequestDto) {
+        Long memberId = MemberUtil.getMemberId(principal);
+        withdrawService.deleteMember(memberId, memberDeleteRequestDto);
+        return ApiResponseDto.success();
+    }
+}

--- a/src/main/java/site/katchup/katchupserver/api/member/controller/WithdrawController.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/controller/WithdrawController.java
@@ -16,9 +16,9 @@ import site.katchup.katchupserver.common.util.MemberUtil;
 import java.security.Principal;
 
 @RestController
-@RequestMapping("/api/v1/members")
+@RequestMapping("/api/v1/withdraws")
 @RequiredArgsConstructor
-@Tag(name = "[Member] 회원 탈퇴 관련 API (V1)")
+@Tag(name = "[Withdraw] 회원 탈퇴 관련 API (V1)")
 public class WithdrawController {
     private final WithdrawService withdrawService;
 

--- a/src/main/java/site/katchup/katchupserver/api/member/domain/Member.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/domain/Member.java
@@ -51,8 +51,9 @@ public class Member extends BaseEntity {
         updateUserUUID();
     }
 
-    public void updateMemberStatus(boolean isNewUser, String refreshToken) {
+    public void updateMemberStatus(boolean isNewUser, boolean isDeleted, String refreshToken) {
         this.isNewUser = isNewUser;
+        this.isDeleted = isDeleted;
         this.refreshToken = refreshToken;
     }
 

--- a/src/main/java/site/katchup/katchupserver/api/member/domain/Member.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/domain/Member.java
@@ -62,5 +62,9 @@ public class Member extends BaseEntity {
         int l = ByteBuffer.wrap(uuid.getBytes()).getInt();
         this.userUUID = Integer.toString(l,9);
     }
+
+    public void deleted() {
+        this.isDeleted = true;
+    }
 }
 

--- a/src/main/java/site/katchup/katchupserver/api/member/domain/Withdraw.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/domain/Withdraw.java
@@ -9,6 +9,7 @@ import org.springframework.data.annotation.CreatedDate;
 import java.time.LocalDateTime;
 
 import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
 import static java.time.LocalDateTime.now;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -16,22 +17,24 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 public class Withdraw {
-
     @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 2000)
     private String reason;
 
     @CreatedDate
-    private LocalDateTime createdAt;
+    private LocalDateTime deletedAt;
 
     @Builder
     public Withdraw(Member member, String reason) {
         this.member = member;
         this.reason = reason;
-        this.createdAt = now();
+        this.deletedAt = now();
     }
 }

--- a/src/main/java/site/katchup/katchupserver/api/member/domain/Withdraw.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/domain/Withdraw.java
@@ -35,6 +35,6 @@ public class Withdraw {
     public Withdraw(Member member, String reason) {
         this.member = member;
         this.reason = reason;
-        this.deletedAt = now();
+        this.deletedAt = now().plusDays(60);
     }
 }

--- a/src/main/java/site/katchup/katchupserver/api/member/domain/Withdraw.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/domain/Withdraw.java
@@ -29,12 +29,12 @@ public class Withdraw {
     private String reason;
 
     @CreatedDate
-    private LocalDateTime deletedAt;
+    private LocalDateTime expectedDeleteAt;
 
     @Builder
     public Withdraw(Member member, String reason) {
         this.member = member;
         this.reason = reason;
-        this.deletedAt = now().plusDays(60);
+        this.expectedDeleteAt = now().plusDays(60);
     }
 }

--- a/src/main/java/site/katchup/katchupserver/api/member/dto/request/MemberDeleteRequestDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/dto/request/MemberDeleteRequestDto.java
@@ -1,0 +1,16 @@
+package site.katchup.katchupserver.api.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@NoArgsConstructor(access = PRIVATE)
+@AllArgsConstructor
+public class MemberDeleteRequestDto {
+    @NotBlank
+    private String reason;
+}

--- a/src/main/java/site/katchup/katchupserver/api/member/dto/response/MemberProfileGetResponseDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/dto/response/MemberProfileGetResponseDto.java
@@ -1,4 +1,4 @@
-package site.katchup.katchupserver.api.member.dto;
+package site.katchup.katchupserver.api.member.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;

--- a/src/main/java/site/katchup/katchupserver/api/member/repository/WithdrawRepository.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/repository/WithdrawRepository.java
@@ -1,0 +1,7 @@
+package site.katchup.katchupserver.api.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.katchup.katchupserver.api.member.domain.Withdraw;
+
+public interface WithdrawRepository extends JpaRepository<Withdraw, Long> {
+}

--- a/src/main/java/site/katchup/katchupserver/api/member/service/Impl/MemberServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/service/Impl/MemberServiceImpl.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.katchup.katchupserver.api.member.domain.Member;
-import site.katchup.katchupserver.api.member.dto.MemberProfileGetResponseDto;
+import site.katchup.katchupserver.api.member.dto.response.MemberProfileGetResponseDto;
 import site.katchup.katchupserver.api.member.repository.MemberRepository;
 import site.katchup.katchupserver.api.member.service.MemberService;
 

--- a/src/main/java/site/katchup/katchupserver/api/member/service/Impl/WithdrawServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/service/Impl/WithdrawServiceImpl.java
@@ -1,0 +1,33 @@
+package site.katchup.katchupserver.api.member.service.Impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.katchup.katchupserver.api.member.domain.Member;
+import site.katchup.katchupserver.api.member.domain.Withdraw;
+import site.katchup.katchupserver.api.member.dto.request.MemberDeleteRequestDto;
+import site.katchup.katchupserver.api.member.repository.MemberRepository;
+import site.katchup.katchupserver.api.member.repository.WithdrawRepository;
+import site.katchup.katchupserver.api.member.service.WithdrawService;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WithdrawServiceImpl implements WithdrawService {
+
+    private final WithdrawRepository withdrawRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    @Transactional
+    public void deleteMember(Long memberId, MemberDeleteRequestDto memberDeleteRequestDto) {
+        Withdraw withdraw = Withdraw.builder()
+                .member(memberRepository.findByIdOrThrow(memberId))
+                .reason(memberDeleteRequestDto.getReason())
+                .build();
+        withdrawRepository.save(withdraw);
+
+        Member member = memberRepository.findByIdOrThrow(memberId);
+        member.deleted();
+    }
+}

--- a/src/main/java/site/katchup/katchupserver/api/member/service/Impl/WithdrawServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/service/Impl/WithdrawServiceImpl.java
@@ -3,12 +3,19 @@ package site.katchup.katchupserver.api.member.service.Impl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import site.katchup.katchupserver.api.card.domain.Card;
+import site.katchup.katchupserver.api.category.domain.Category;
+import site.katchup.katchupserver.api.category.repository.CategoryRepository;
 import site.katchup.katchupserver.api.member.domain.Member;
 import site.katchup.katchupserver.api.member.domain.Withdraw;
 import site.katchup.katchupserver.api.member.dto.request.MemberDeleteRequestDto;
 import site.katchup.katchupserver.api.member.repository.MemberRepository;
 import site.katchup.katchupserver.api.member.repository.WithdrawRepository;
 import site.katchup.katchupserver.api.member.service.WithdrawService;
+import site.katchup.katchupserver.api.subTask.domain.SubTask;
+import site.katchup.katchupserver.api.task.domain.Task;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +24,7 @@ public class WithdrawServiceImpl implements WithdrawService {
 
     private final WithdrawRepository withdrawRepository;
     private final MemberRepository memberRepository;
+    private final CategoryRepository categoryRepository;
 
     @Override
     @Transactional
@@ -29,5 +37,20 @@ public class WithdrawServiceImpl implements WithdrawService {
 
         Member member = memberRepository.findByIdOrThrow(memberId);
         member.deleted();
+
+        List<Category> categoryList = categoryRepository.findAllByMemberId(memberId);
+
+        categoryList.forEach(Category::deleted);
+        categoryList.forEach(category ->
+            category.getTasks().forEach(this::deleteTaskAndSubTaskAndCard));
+
+    }
+
+    private void deleteTaskAndSubTaskAndCard(Task task) {
+        task.deleted();
+        task.getSubTasks().forEach(SubTask::deleted);
+        task.getSubTasks().stream()
+                .flatMap(subTask -> subTask.getCards().stream())
+                .forEach(Card::deletedCard);
     }
 }

--- a/src/main/java/site/katchup/katchupserver/api/member/service/MemberService.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/service/MemberService.java
@@ -1,6 +1,6 @@
 package site.katchup.katchupserver.api.member.service;
 
-import site.katchup.katchupserver.api.member.dto.MemberProfileGetResponseDto;
+import site.katchup.katchupserver.api.member.dto.response.MemberProfileGetResponseDto;
 
 public interface MemberService {
 

--- a/src/main/java/site/katchup/katchupserver/api/member/service/WithdrawService.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/service/WithdrawService.java
@@ -1,0 +1,7 @@
+package site.katchup.katchupserver.api.member.service;
+
+import site.katchup.katchupserver.api.member.dto.request.MemberDeleteRequestDto;
+
+public interface WithdrawService {
+    void deleteMember(Long memberId, MemberDeleteRequestDto memberDeleteRequestDto);
+}


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
회원 탈퇴 API를 구현하였습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 회원탈퇴 시, 탈퇴 사유를 withdraw 테이블에 저장합니다.
- 회원탈퇴 시, 해당 회원이 쓴 인수인계 기록을 모두 softdelete 합니다.
- 기획 측의 요청에 따라 회원탈퇴 날로부터 몇 일이 지났는지를 계산하기 위해 withdraw 테이블에 deletedAt 필드를 추가하였습니다. (@CreatedDate 이지만 필드명만 deletedAt 입니다. 직관성을 위해)
- 회원탈퇴 후 재로그인 시, isNewUser=True, isDeleted=False 로 값을 변경합니다.
- 다음 스프린트에서 회원탈퇴 후 60일이 지나면 실제 기록을 삭제하는 로직이 추가되어야 합니다.
![회탈](https://github.com/Katchup-dev/Katchup-server/assets/64405757/3dd3571f-5fd5-4d9a-a51c-1ef0017de4ed)


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #152 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
