### PR TITLE
[FEAT] 카테고리별 공유 활성화 토글 변경 api

### DIFF
--- a/src/main/java/site/katchup/katchupserver/api/category/controller/CategoryController.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/controller/CategoryController.java
@@ -93,7 +93,7 @@ public class CategoryController {
             @ApiResponse(responseCode = "400", description = "카테고리 공유 활성화 토글 변경 실패", content = @Content),
             @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     })
-    @PatchMapping("/{categoryId}/SharedStatus")
+    @PatchMapping("/{categoryId}/sharedStatus")
     @ResponseStatus(HttpStatus.OK)
     public ApiResponseDto<CategoryPatchSharedStatusResponseDto> toggleSharedStatus(@PathVariable Long categoryId) {
         CategoryPatchSharedStatusResponseDto categorySharedStatusDto = categoryService.toggleSharedStatus(categoryId);

--- a/src/main/java/site/katchup/katchupserver/api/category/controller/CategoryController.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/controller/CategoryController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import site.katchup.katchupserver.api.category.dto.request.CategoryCreateRequestDto;
 import site.katchup.katchupserver.api.category.dto.request.CategoryUpdateRequestDto;
 import site.katchup.katchupserver.api.category.dto.response.CategoryGetResponseDto;
+import site.katchup.katchupserver.api.category.dto.response.CategoryPatchSharedStatusResponseDto;
 import site.katchup.katchupserver.api.category.service.CategoryService;
 import site.katchup.katchupserver.common.dto.ApiResponseDto;
 import site.katchup.katchupserver.common.util.MemberUtil;
@@ -84,5 +85,18 @@ public class CategoryController {
     public ApiResponseDto deleteCategory(@PathVariable Long categoryId) {
         categoryService.deleteCategory(categoryId);
         return ApiResponseDto.success();
+    }
+
+    @Operation(summary = "카테고리 공유 활성화 토글 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "카테고리 공유 활성화 토글 변경 성공"),
+            @ApiResponse(responseCode = "400", description = "카테고리 공유 활성화 토글 변경 실패", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    })
+    @PatchMapping("/{categoryId}/SharedStatus")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<CategoryPatchSharedStatusResponseDto> toggleSharedStatus(@PathVariable Long categoryId) {
+        CategoryPatchSharedStatusResponseDto categorySharedStatusDto = categoryService.toggleSharedStatus(categoryId);
+        return ApiResponseDto.success(categorySharedStatusDto);
     }
 }

--- a/src/main/java/site/katchup/katchupserver/api/category/controller/CategoryController.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/controller/CategoryController.java
@@ -93,7 +93,7 @@ public class CategoryController {
             @ApiResponse(responseCode = "400", description = "카테고리 공유 활성화 토글 변경 실패", content = @Content),
             @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     })
-    @PatchMapping("/{categoryId}/sharedStatus")
+    @PatchMapping("/{categoryId}/share")
     @ResponseStatus(HttpStatus.OK)
     public ApiResponseDto<CategoryPatchSharedStatusResponseDto> toggleSharedStatus(@PathVariable Long categoryId) {
         CategoryPatchSharedStatusResponseDto categorySharedStatusDto = categoryService.toggleSharedStatus(categoryId);

--- a/src/main/java/site/katchup/katchupserver/api/category/domain/Category.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/domain/Category.java
@@ -66,4 +66,7 @@ public class Category extends BaseEntity {
         this.name = newName;
     }
 
+    public void toggleSharedStatus() {
+        isShared = !isShared;
+    }
 }

--- a/src/main/java/site/katchup/katchupserver/api/category/dto/response/CategoryPatchSharedStatusResponseDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/dto/response/CategoryPatchSharedStatusResponseDto.java
@@ -1,0 +1,18 @@
+package site.katchup.katchupserver.api.category.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@NoArgsConstructor(access = PRIVATE)
+@AllArgsConstructor
+public class CategoryPatchSharedStatusResponseDto {
+    private Boolean isShared;
+
+    public static CategoryPatchSharedStatusResponseDto of(boolean isShared) {
+        return new CategoryPatchSharedStatusResponseDto(isShared);
+    }
+}

--- a/src/main/java/site/katchup/katchupserver/api/category/service/CategoryService.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/service/CategoryService.java
@@ -3,6 +3,7 @@ package site.katchup.katchupserver.api.category.service;
 import site.katchup.katchupserver.api.category.dto.request.CategoryCreateRequestDto;
 import site.katchup.katchupserver.api.category.dto.request.CategoryUpdateRequestDto;
 import site.katchup.katchupserver.api.category.dto.response.CategoryGetResponseDto;
+import site.katchup.katchupserver.api.category.dto.response.CategoryPatchSharedStatusResponseDto;
 
 import java.util.List;
 
@@ -12,5 +13,6 @@ public interface CategoryService {
     List<CategoryGetResponseDto> getAllCategory(Long memberId);
     void updateCategoryName(Long memberId, Long categoryId, CategoryUpdateRequestDto categoryUpdateRequestDto);
     void deleteCategory(Long categoryId);
+    CategoryPatchSharedStatusResponseDto toggleSharedStatus(Long categoryId);
 
 }


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
- 카테고리별 공유 활성화 토글 api를 개발했습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- Category 내의 is_shared 값을 토글 형식으로 변환하도록 api를 개발하였습니다.
<img width="1163" alt="image" src="https://github.com/Katchup-dev/Katchup-server/assets/68415644/31a580ae-41f1-4c72-9780-bfa125b40480">
<img width="572" alt="image" src="https://github.com/Katchup-dev/Katchup-server/assets/68415644/c4617321-2218-4488-93ca-c827f4e90967">
<img width="1124" alt="image" src="https://github.com/Katchup-dev/Katchup-server/assets/68415644/a45608f8-c7eb-4ecb-97d3-cbcb38fc5534">

- 펀딩 왼쪽 옆에 필드 값이 is_shared 값입니다.

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #161 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
