### PR TITLE
[FEAT] 카테고리 목록 조회 시, 공유 활성화 된 카테고리만 내려주는 로직 추가

### DIFF
--- a/src/main/java/site/katchup/katchupserver/api/category/controller/CategoryController.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/controller/CategoryController.java
@@ -93,7 +93,7 @@ public class CategoryController {
             @ApiResponse(responseCode = "400", description = "카테고리 공유 활성화 토글 변경 실패", content = @Content),
             @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     })
-    @PatchMapping("/{categoryId}/SharedStatus")
+    @PatchMapping("/{categoryId}/sharedStatus")
     @ResponseStatus(HttpStatus.OK)
     public ApiResponseDto<CategoryPatchSharedStatusResponseDto> toggleSharedStatus(@PathVariable Long categoryId) {
         CategoryPatchSharedStatusResponseDto categorySharedStatusDto = categoryService.toggleSharedStatus(categoryId);

--- a/src/main/java/site/katchup/katchupserver/api/category/controller/CategoryController.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/controller/CategoryController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import site.katchup.katchupserver.api.category.dto.request.CategoryCreateRequestDto;
 import site.katchup.katchupserver.api.category.dto.request.CategoryUpdateRequestDto;
 import site.katchup.katchupserver.api.category.dto.response.CategoryGetResponseDto;
+import site.katchup.katchupserver.api.category.dto.response.CategoryPatchSharedStatusResponseDto;
 import site.katchup.katchupserver.api.category.service.CategoryService;
 import site.katchup.katchupserver.common.dto.ApiResponseDto;
 import site.katchup.katchupserver.common.util.MemberUtil;
@@ -84,5 +85,18 @@ public class CategoryController {
     public ApiResponseDto deleteCategory(@PathVariable Long categoryId) {
         categoryService.deleteCategory(categoryId);
         return ApiResponseDto.success();
+    }
+
+    @Operation(summary = "카테고리 공유 활성화 토글 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "카테고리 공유 활성화 토글 변경 성공"),
+            @ApiResponse(responseCode = "400", description = "카테고리 공유 활성화 토글 변경 실패", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    })
+    @PatchMapping("/{categoryId}/SharedStatus")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<CategoryPatchSharedStatusResponseDto> toggleSharedStatus(@PathVariable Long categoryId) {
+        CategoryPatchSharedStatusResponseDto categorySharedStatusDto = categoryService.toggleSharedStatus(categoryId);
+        return ApiResponseDto.success(categorySharedStatusDto);
     }
 }

--- a/src/main/java/site/katchup/katchupserver/api/category/controller/CategoryController.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/controller/CategoryController.java
@@ -46,17 +46,21 @@ public class CategoryController {
         return ApiResponseDto.success();
     }
 
-    @Operation(summary = "카테고리 조회 API")
+    @Operation(summary = "카테고리 목록 조회 API")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "카테고리 조회 성공"),
-            @ApiResponse(responseCode = "400", description = "카테고리 조회 실패", content = @Content),
+            @ApiResponse(responseCode = "200", description = "카테고리 목록 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "카테고리 목록 조회 실패", content = @Content),
             @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     })
     @GetMapping()
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponseDto<List<CategoryGetResponseDto>> getAllCategory(Principal principal) {
+    public ApiResponseDto<List<CategoryGetResponseDto>> getAllCategory(Principal principal,
+                                                                       @RequestParam(name = "isShared", required = false) Boolean isShared) {
         Long memberId = MemberUtil.getMemberId(principal);
-        return ApiResponseDto.success(categoryService.getAllCategory(memberId));
+        if (isShared != null && isShared) {
+            return ApiResponseDto.success(categoryService.getSharedCategories(memberId));
+        }
+        return ApiResponseDto.success(categoryService.getAllCategories(memberId));
     }
 
     @Operation(summary = "카테고리 이름 수정 API")

--- a/src/main/java/site/katchup/katchupserver/api/category/domain/Category.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/domain/Category.java
@@ -66,4 +66,7 @@ public class Category extends BaseEntity {
         this.name = newName;
     }
 
+    public void toggleSharedStatus() {
+        isShared = !isShared;
+    }
 }

--- a/src/main/java/site/katchup/katchupserver/api/category/dto/response/CategoryPatchSharedStatusResponseDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/dto/response/CategoryPatchSharedStatusResponseDto.java
@@ -1,0 +1,18 @@
+package site.katchup.katchupserver.api.category.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@NoArgsConstructor(access = PRIVATE)
+@AllArgsConstructor
+public class CategoryPatchSharedStatusResponseDto {
+    private Boolean isShared;
+
+    public static CategoryPatchSharedStatusResponseDto of(boolean isShared) {
+        return new CategoryPatchSharedStatusResponseDto(isShared);
+    }
+}

--- a/src/main/java/site/katchup/katchupserver/api/category/repository/CategoryRepository.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/repository/CategoryRepository.java
@@ -21,6 +21,9 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     @Query("select c from Category c where c.member.id = :memberId and c.isDeleted = false")
     List<Category> findAllByMemberIdAndNotDeleted(@Param("memberId") Long memberId);
 
+    @Query("select c from Category c where c.member.id = :memberId and c.isDeleted = false and c.isShared = true")
+    List<Category> findAllByMemberIdAndNotDeletedAndIsShared(@Param("memberId") Long memberId);
+
     List<Category> findAllByMemberId(Long memberId);
 
     default Category findByIdOrThrow(Long categoryId) {

--- a/src/main/java/site/katchup/katchupserver/api/category/service/CategoryService.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/service/CategoryService.java
@@ -10,7 +10,8 @@ import java.util.List;
 public interface CategoryService {
 
     Long createCategoryName(Long memberId, CategoryCreateRequestDto categoryCreateRequestDto);
-    List<CategoryGetResponseDto> getAllCategory(Long memberId);
+    List<CategoryGetResponseDto> getAllCategories(Long memberId);
+    List<CategoryGetResponseDto> getSharedCategories(Long memberId);
     void updateCategoryName(Long memberId, Long categoryId, CategoryUpdateRequestDto categoryUpdateRequestDto);
     void deleteCategory(Long categoryId);
     CategoryPatchSharedStatusResponseDto toggleSharedStatus(Long categoryId);

--- a/src/main/java/site/katchup/katchupserver/api/category/service/CategoryService.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/service/CategoryService.java
@@ -3,6 +3,7 @@ package site.katchup.katchupserver.api.category.service;
 import site.katchup.katchupserver.api.category.dto.request.CategoryCreateRequestDto;
 import site.katchup.katchupserver.api.category.dto.request.CategoryUpdateRequestDto;
 import site.katchup.katchupserver.api.category.dto.response.CategoryGetResponseDto;
+import site.katchup.katchupserver.api.category.dto.response.CategoryPatchSharedStatusResponseDto;
 
 import java.util.List;
 
@@ -12,5 +13,6 @@ public interface CategoryService {
     List<CategoryGetResponseDto> getAllCategory(Long memberId);
     void updateCategoryName(Long memberId, Long categoryId, CategoryUpdateRequestDto categoryUpdateRequestDto);
     void deleteCategory(Long categoryId);
+    CategoryPatchSharedStatusResponseDto toggleSharedStatus(Long categoryId);
 
 }

--- a/src/main/java/site/katchup/katchupserver/api/category/service/Impl/CategoryServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/service/Impl/CategoryServiceImpl.java
@@ -46,8 +46,15 @@ public class CategoryServiceImpl implements CategoryService {
     }
 
     @Override
-    public List<CategoryGetResponseDto> getAllCategory(Long memberId) {
+    public List<CategoryGetResponseDto> getAllCategories(Long memberId) {
         return categoryRepository.findAllByMemberIdAndNotDeleted(memberId).stream()
+                .map(category -> CategoryGetResponseDto.of(category.getId(), category.getName(), category.isShared()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<CategoryGetResponseDto> getSharedCategories(Long memberId) {
+        return categoryRepository.findAllByMemberIdAndNotDeletedAndIsShared(memberId).stream()
                 .map(category -> CategoryGetResponseDto.of(category.getId(), category.getName(), category.isShared()))
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
- 카테고리 목록 조회 시, 공유 활성화 된 카테고리만 내려주는 로직을 추가했습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 기존 `GET api/v1/categories` api에 `isShared` 값을 쿼리로 optional하게 받도록 해서, 이 값을 true로 보내면 카테고리들 중 공유 활성화가 된 카테고리들만 내려주도록 했습니다.

- 모든 카테고리 목록 조회 -> isShared를 쿼리로 받지 않음
<img width="472" alt="image" src="https://github.com/Katchup-dev/Katchup-server/assets/68415644/743fb76b-101c-49d9-af56-843d1fe3be7e">

- 공유 활성화 토글이 on된 카테고리 목록만 조회 -> isShared=true를 쿼리로 받음
<img width="439" alt="image" src="https://github.com/Katchup-dev/Katchup-server/assets/68415644/9e0f619b-14e4-4bc4-855d-cc10a8a49b69">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #163 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
