### PR TITLE
[REFACTOR] S3 구조 수정

### DIFF
--- a/src/main/java/site/katchup/katchupserver/external/s3/AwsS3Config.java
+++ b/src/main/java/site/katchup/katchupserver/external/s3/AwsS3Config.java
@@ -1,4 +1,4 @@
-package site.katchup.katchupserver.config;
+package site.katchup.katchupserver.external.s3;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;

--- a/src/main/java/site/katchup/katchupserver/external/s3/PreSignedUrlVO.java
+++ b/src/main/java/site/katchup/katchupserver/external/s3/PreSignedUrlVO.java
@@ -1,0 +1,12 @@
+package site.katchup.katchupserver.external.s3;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor(staticName = "of")
+public class PreSignedUrlVO {
+    private String fileName;
+    private String fileUploadDate;
+    private String preSignedUrl;
+}

--- a/src/main/java/site/katchup/katchupserver/external/s3/S3Service.java
+++ b/src/main/java/site/katchup/katchupserver/external/s3/S3Service.java
@@ -1,4 +1,4 @@
-package site.katchup.katchupserver.common.util;
+package site.katchup.katchupserver.external.s3;
 
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
@@ -17,38 +17,29 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
-public class S3Util {
-
-    public static final String KEY_FILENAME = "fileName";
-    public static final String KEY_FILE_UPLOAD_DATE = "fileUploadDate";
-
-    public static final String KEY_PRESIGNED_URL = "preSignedUrl";
+public class S3Service {
 
     private final AmazonS3 amazonS3;
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
     @Value("${cloud.aws.region.static}")
-    private String location;
+    private String region;
 
-    public HashMap<String, String> generatePreSignedUrl(String prefix, String fileName) {
-        HashMap<String, String> result = new HashMap<>();
+    public PreSignedUrlVO generatePreSignedUrl(String prefix, String fileName) {
         String uuidFileName = getUUIDFile();
-        result.put(KEY_FILENAME, uuidFileName);
         String filePath = prefix + "/" + getDateFolder() + "/" + uuidFileName + fileName;
         GeneratePresignedUrlRequest generatePresignedUrlRequest = getGeneratePreSignedUrlRequest(bucket, filePath);
-        result.put(KEY_PRESIGNED_URL, amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString());
-        result.put(KEY_FILE_UPLOAD_DATE, getDateFolder());
-        return result;
+        String presignedUrl = amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
+        return PreSignedUrlVO.of(uuidFileName, getDateFolder(), presignedUrl);
     }
 
     public String findUrlByName(String path) {
-        return "https://" + bucket + ".s3." + location + ".amazonaws.com/" + path;
+        return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + path;
     }
 
     public String getDownloadPreSignedUrl(String filePath, String fileName) {


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
S3 관련 리팩토링을 진행했습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- S3관련 코드를 외부 의존하고 있는 모듈을 따로 관리하는 것이 좋다고 판단하여 external package로 이동시켰습니다. 이후에 다른 외부 의존성 이 추가될 경우 해당 package에서 관리 되면 좋을 것 같습니다.
- S3Util에서 하는 기능이 S3Util보다는 Service 로직의 역할을 하고 있다고 판단하여  S3Service로 클래스 이름을 바꿨습니다. 
- 기존 PreSignedUrl을 응답해주는 class로 HashMap을 활용했었는데, HashMap을 사용할 경우, 이후에 PreSignedUrl을 받아오는 다른 method가 생길경우 재사용이 어렵다고 판단하여, 응답 객체를 만들어 리팩토링 했습니당.
 
## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
한 PR에서 프로필 수정 기능까지 개발하려고 했는데... 기능이 너무 커져서, 나눠서 PR올립니다.
이후에 AWS 의존성 교체하고 프로필 수정 API 개발 진행하겠습니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #165 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
