### PR TITLE
[CHORE] withdraw table 변경

### DIFF
--- a/src/main/java/site/katchup/katchupserver/api/member/domain/Withdraw.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/domain/Withdraw.java
@@ -5,8 +5,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import site.katchup.katchupserver.common.util.StringListConverter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -26,13 +28,14 @@ public class Withdraw {
     private Member member;
 
     @Column(nullable = false, length = 2000)
-    private String reason;
+    @Convert(converter = StringListConverter.class)
+    private List<String> reason;
 
     @CreatedDate
     private LocalDateTime expectedDeleteAt;
 
     @Builder
-    public Withdraw(Member member, String reason) {
+    public Withdraw(Member member, List<String> reason) {
         this.member = member;
         this.reason = reason;
         this.expectedDeleteAt = now().plusDays(60);

--- a/src/main/java/site/katchup/katchupserver/api/member/dto/request/MemberDeleteRequestDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/dto/request/MemberDeleteRequestDto.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 import static lombok.AccessLevel.PRIVATE;
 
 @Getter
@@ -12,5 +14,5 @@ import static lombok.AccessLevel.PRIVATE;
 @AllArgsConstructor
 public class MemberDeleteRequestDto {
     @NotBlank
-    private String reason;
+    private List<String> reason;
 }

--- a/src/main/java/site/katchup/katchupserver/common/util/StringListConverter.java
+++ b/src/main/java/site/katchup/katchupserver/common/util/StringListConverter.java
@@ -1,0 +1,33 @@
+package site.katchup.katchupserver.common.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import jakarta.persistence.AttributeConverter;
+
+import java.util.List;
+
+public class StringListConverter implements AttributeConverter<List<String>, String> {
+    private static final ObjectMapper mapper = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false);
+
+    @Override
+    public String convertToDatabaseColumn(List attribute) {
+        try {
+            return mapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+        try {
+            return mapper.readValue(dbData, List.class);
+        } catch (IOException e) {
+            throw new IllegalArgumentException();
+        }
+    }
+}


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
탈퇴 사유 복수 응답이 가능함에 따라 reason 컬럼을 배열로 받을 수 있도록 수정하였습니다.


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
배열로 API 요청하면 withdraw 필드의 reason 필드에 리스트 형태로 저장됩니다.
![32](https://github.com/Katchup-dev/Katchup-server/assets/64405757/ec4dd8ff-de8e-46ac-baf9-50106b5881f2)


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #172 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
