### PR TITLE
[FEAT] 프로필 수정 API 개발

### DIFF
--- a/src/main/java/site/katchup/katchupserver/api/auth/service/Impl/AuthServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/auth/service/Impl/AuthServiceImpl.java
@@ -56,7 +56,7 @@ public class AuthServiceImpl implements AuthService {
 
         String accessToken = jwtTokenProvider.generateAccessToken(authentication);
 
-        String nickname = signedMember.getNickname();
+        String nickname = signedMember.getMemberProfile().getNickname();
 
         return AuthLoginResponseDto.builder()
                 .nickname(nickname)

--- a/src/main/java/site/katchup/katchupserver/api/member/controller/MemberController.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/controller/MemberController.java
@@ -5,8 +5,11 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import site.katchup.katchupserver.api.member.dto.request.MemberProfileUpdateRequestDto;
 import site.katchup.katchupserver.api.member.dto.response.MemberProfileGetResponseDto;
 import site.katchup.katchupserver.api.member.service.MemberService;
 import site.katchup.katchupserver.common.dto.ApiResponseDto;
@@ -35,4 +38,17 @@ public class MemberController {
 
         return ApiResponseDto.success(responseDto);
     }
+
+    @Operation(summary = "회원 프로필 수정 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원 프로필 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "회원 프로필 수정 실패", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    })
+    @PutMapping("/profile/me")
+    public ApiResponseDto updateMemberProfile(@RequestPart("profileImage") MultipartFile profileImage, @Valid MemberProfileUpdateRequestDto request, Principal principal) {
+        memberService.updateMemberProfile(MemberUtil.getMemberId(principal), profileImage, request);
+        return ApiResponseDto.success();
+    }
+
 }

--- a/src/main/java/site/katchup/katchupserver/api/member/domain/Member.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/domain/Member.java
@@ -19,14 +19,10 @@ public class Member extends BaseEntity {
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 20)
-    private String nickname;
+    @Embedded
+    MemberProfile memberProfile;
 
-    @Column(nullable = false)
     private String email;
-
-    @Column(name = "image_url")
-    private String imageUrl;
 
     @Column(name = "user_UUID", nullable = false)
     private String userUUID;
@@ -42,9 +38,9 @@ public class Member extends BaseEntity {
 
     @Builder
     public Member(String nickname, String email, String imageUrl, boolean isDeleted, boolean isNewUser, String refreshToken) {
-        this.nickname = nickname;
+        // TODO: default introduction 어떻게 할지에 따라 수정
+        this.memberProfile = new MemberProfile(nickname, "", imageUrl);
         this.email = email;
-        this.imageUrl = imageUrl;
         this.isDeleted = isDeleted;
         this.isNewUser = isNewUser;
         this.refreshToken = refreshToken;
@@ -55,6 +51,10 @@ public class Member extends BaseEntity {
         this.isNewUser = isNewUser;
         this.isDeleted = isDeleted;
         this.refreshToken = refreshToken;
+    }
+
+    public void updateMemberProfile(MemberProfile memberProfile) {
+        this.memberProfile = memberProfile;
     }
 
     public void clearRefreshToken() {

--- a/src/main/java/site/katchup/katchupserver/api/member/domain/MemberProfile.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/domain/MemberProfile.java
@@ -1,2 +1,31 @@
-package site.katchup.katchupserver.api.member.domain;public class MemberProfile {
+package site.katchup.katchupserver.api.member.domain;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Embeddable
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@Getter
+public class MemberProfile {
+
+    @Column(nullable = false, length = 20)
+    private String nickname;
+
+    private String introduction;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+
+    @Builder
+    public MemberProfile(String nickname, String introduction, String imageUrl) {
+        this.nickname = nickname;
+        this.introduction = introduction;
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/site/katchup/katchupserver/api/member/domain/MemberProfile.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/domain/MemberProfile.java
@@ -1,0 +1,2 @@
+package site.katchup.katchupserver.api.member.domain;public class MemberProfile {
+}

--- a/src/main/java/site/katchup/katchupserver/api/member/dto/request/MemberProfileUpdateRequestDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/dto/request/MemberProfileUpdateRequestDto.java
@@ -13,6 +13,7 @@ public class MemberProfileUpdateRequestDto {
     @Schema(description = "회원 닉네임", example = "unan")
     @NotNull
     private String nickname;
+    @Schema(description = "회원 한줄 소개", example = "안녕하세요")
     @NotNull
     private String introduction;
 }

--- a/src/main/java/site/katchup/katchupserver/api/member/dto/request/MemberProfileUpdateRequestDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/dto/request/MemberProfileUpdateRequestDto.java
@@ -1,0 +1,2 @@
+package site.katchup.katchupserver.api.member.dto.request;public class MemberProfileUpdateRequestDto {
+}

--- a/src/main/java/site/katchup/katchupserver/api/member/dto/request/MemberProfileUpdateRequestDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/dto/request/MemberProfileUpdateRequestDto.java
@@ -1,2 +1,18 @@
-package site.katchup.katchupserver.api.member.dto.request;public class MemberProfileUpdateRequestDto {
+package site.katchup.katchupserver.api.member.dto.request;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+@Schema(description = "회원 프로필 수정 요청 DTO")
+public class MemberProfileUpdateRequestDto {
+    @Schema(description = "회원 닉네임", example = "unan")
+    @NotNull
+    private String nickname;
+    @NotNull
+    private String introduction;
 }

--- a/src/main/java/site/katchup/katchupserver/api/member/dto/response/MemberProfileGetResponseDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/dto/response/MemberProfileGetResponseDto.java
@@ -2,10 +2,11 @@ package site.katchup.katchupserver.api.member.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import site.katchup.katchupserver.api.member.domain.Member;
 
 @Data
-@AllArgsConstructor
 @Schema(description = "회원 응답 DTO")
 public class MemberProfileGetResponseDto {
 
@@ -15,4 +16,19 @@ public class MemberProfileGetResponseDto {
     private String nickname;
     @Schema(description = "회원 이메일", example = "katchup@katchup.com")
     private String email;
+
+    @Builder
+    public MemberProfileGetResponseDto(String imageUrl, String nickname, String email) {
+        this.imageUrl = imageUrl;
+        this.nickname = nickname;
+        this.email = email;
+    }
+
+    public static MemberProfileGetResponseDto of(Member member) {
+        return MemberProfileGetResponseDto.builder()
+                .imageUrl(member.getMemberProfile().getImageUrl())
+                .nickname(member.getMemberProfile().getNickname())
+                .email(member.getEmail())
+                .build();
+    }
 }

--- a/src/main/java/site/katchup/katchupserver/api/member/service/Impl/MemberServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/service/Impl/MemberServiceImpl.java
@@ -3,22 +3,50 @@ package site.katchup.katchupserver.api.member.service.Impl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import site.katchup.katchupserver.api.member.domain.Member;
+import site.katchup.katchupserver.api.member.domain.MemberProfile;
+import site.katchup.katchupserver.api.member.dto.request.MemberProfileUpdateRequestDto;
 import site.katchup.katchupserver.api.member.dto.response.MemberProfileGetResponseDto;
 import site.katchup.katchupserver.api.member.repository.MemberRepository;
 import site.katchup.katchupserver.api.member.service.MemberService;
+import site.katchup.katchupserver.common.exception.InternalServerException;
+import site.katchup.katchupserver.common.response.ErrorCode;
+import site.katchup.katchupserver.external.s3.S3Service;
+
+import java.io.IOException;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MemberServiceImpl implements MemberService {
+    private static final String PROFILE_IMAGE_PREFIX = "profiles";
+
     private final MemberRepository memberRepository;
+    private final S3Service s3Service;
 
     @Override
     public MemberProfileGetResponseDto getMemberProfile(Long memberId) {
         Member member = memberRepository.findByIdOrThrow(memberId);
 
-        return new MemberProfileGetResponseDto(member.getImageUrl(), member.getNickname(), member.getEmail());
+        return MemberProfileGetResponseDto.of(member);
+    }
+
+    @Override
+    @Transactional
+    public void updateMemberProfile(Long memberId, MultipartFile profileImage, MemberProfileUpdateRequestDto request) {
+        Member member = memberRepository.findByIdOrThrow(memberId);
+        try {
+            String key = s3Service.uploadImage( s3Service.makeUploadPrefix(member.getUserUUID(), PROFILE_IMAGE_PREFIX) , profileImage);
+            member.updateMemberProfile(MemberProfile.builder()
+                    .nickname(request.getNickname())
+                    .introduction(request.getIntroduction())
+                    .imageUrl(s3Service.findUrlByName(key))
+                    .build());
+        } catch (IOException e) {
+            throw new InternalServerException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+
     }
 
 }

--- a/src/main/java/site/katchup/katchupserver/api/member/service/MemberService.java
+++ b/src/main/java/site/katchup/katchupserver/api/member/service/MemberService.java
@@ -1,9 +1,12 @@
 package site.katchup.katchupserver.api.member.service;
 
+import org.springframework.web.multipart.MultipartFile;
+import site.katchup.katchupserver.api.member.dto.request.MemberProfileUpdateRequestDto;
 import site.katchup.katchupserver.api.member.dto.response.MemberProfileGetResponseDto;
 
 public interface MemberService {
 
     MemberProfileGetResponseDto getMemberProfile(Long memberId);
+    void updateMemberProfile(Long memberId, MultipartFile profileImage, MemberProfileUpdateRequestDto request);
 
 }

--- a/src/test/java/site/katchup/katchupserver/api/member/domain/MemberTest.java
+++ b/src/test/java/site/katchup/katchupserver/api/member/domain/MemberTest.java
@@ -32,9 +32,9 @@ class MemberTest {
 
         // then
         assertThat(savedMember.getId()).isNotNull();
-        assertThat(savedMember.getNickname()).isEqualTo(member.getNickname());
+        assertThat(savedMember.getMemberProfile().getNickname()).isEqualTo(member.getMemberProfile().getNickname());
         assertThat(savedMember.getEmail()).isEqualTo(member.getEmail());
-        assertThat(savedMember.getImageUrl()).isEqualTo(member.getImageUrl());
+        assertThat(savedMember.getMemberProfile().getImageUrl()).isEqualTo(member.getMemberProfile().getImageUrl());
         assertThat(savedMember.isDeleted()).isEqualTo(member.isDeleted());
         assertThat(savedMember.isNewUser()).isEqualTo(member.isNewUser());
         assertThat(savedMember.getRefreshToken()).isEqualTo(member.getRefreshToken());


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
- 프로필 수정 API 개발을 진행했습니다.
- AWS 자격증명 코드를 수정했습니다.
 
## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->

- Member Entity에 한 줄 소개를 저장하기 위한 introduction 컬럼을 추가했습니다.
- `@Embeddable` 어노테이션을 활용하여 Member Profile 정보를 갖고 있는 MemberProfile 값 객체를 만들었습니다. 이에 따라 Test 코드를 수정했습니다.
- 프로필 수정 API를 개발했습니다. 아래 API Test 문서 첨부합니다.
프로필 수정의 경우 요청이 빈번하게 일어나는 일이 아니라고 생각해서, 클라이언트에서 정보를 보내면 서버에서 직접 업로드하는 방식으로 구현했습니다.( Multipart를 이용)
<img width="969" alt="image" src="https://github.com/Katchup-dev/Katchup-server/assets/81692211/ea107e73-5b80-4752-b4c2-5255430ab959">

- AWS의 임시자격증명을 등록하기 위한 setEnv()를 Spring Bean으로 등록하지 않아, 자격 증명이 발생하지 않는 문제를 해결하기 위해서 코드를 수정했습니다.
(@PostConstruct를 사용했었는데, 외부 라이브러리에 대해서는 @Bean을 사용해야한다는 것을 알았습니다.)

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #142 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
