### PR TITLE
[FIX] 공유용 출력 뷰에서 공유한 유저가 작성한 카테고리 목록을 조회할 수 있도록 수정

### DIFF
--- a/src/main/java/site/katchup/katchupserver/api/auth/dto/response/AuthLoginResponseDto.java
+++ b/src/main/java/site/katchup/katchupserver/api/auth/dto/response/AuthLoginResponseDto.java
@@ -11,6 +11,8 @@ import lombok.Data;
 public class AuthLoginResponseDto {
     @Schema(description = "닉네임", example = "unan")
     private String nickname;
+    @Schema(description = "멤버 고유 id", example = "382")
+    private Long memberId;
     @Schema(description = "Katchup Access Token", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1bmFuIiwiaWF0IjoxNjI0NjQ0NjY2LCJleHAiOj")
     private String accessToken;
     @Schema(description = "Katchup Refresh Token", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1bmFuIiwiaWF0IjoxNjI0NjQ0NjY2LCJleHAiOj")

--- a/src/main/java/site/katchup/katchupserver/api/auth/service/Impl/AuthServiceImpl.java
+++ b/src/main/java/site/katchup/katchupserver/api/auth/service/Impl/AuthServiceImpl.java
@@ -52,7 +52,9 @@ public class AuthServiceImpl implements AuthService {
 
         Member signedMember = memberRepository.findByEmailOrThrow(email);
 
-        Authentication authentication = new UserAuthentication(signedMember.getId(), null, null);
+        Long memberId = signedMember.getId();
+
+        Authentication authentication = new UserAuthentication(memberId, null, null);
 
         String accessToken = jwtTokenProvider.generateAccessToken(authentication);
 
@@ -60,6 +62,7 @@ public class AuthServiceImpl implements AuthService {
 
         return AuthLoginResponseDto.builder()
                 .nickname(nickname)
+                .memberId(memberId)
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .isNewUser(signedMember.isNewUser())

--- a/src/main/java/site/katchup/katchupserver/api/category/controller/CategoryController.java
+++ b/src/main/java/site/katchup/katchupserver/api/category/controller/CategoryController.java
@@ -52,11 +52,10 @@ public class CategoryController {
             @ApiResponse(responseCode = "400", description = "카테고리 목록 조회 실패", content = @Content),
             @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     })
-    @GetMapping()
+    @GetMapping("/{memberId}")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponseDto<List<CategoryGetResponseDto>> getAllCategory(Principal principal,
+    public ApiResponseDto<List<CategoryGetResponseDto>> getAllCategory(@PathVariable final Long memberId,
                                                                        @RequestParam(name = "isShared", required = false) Boolean isShared) {
-        Long memberId = MemberUtil.getMemberId(principal);
         if (isShared != null && isShared) {
             return ApiResponseDto.success(categoryService.getSharedCategories(memberId));
         }


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
- 공유용 출력 뷰에서 공유한 유저가 작성한 카테고리 목록을 조회할 수 있도록 수정

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 현재 카테고리를 조회하는 api는 토큰의 payload에 담겨있는 memberId를 꺼내서 해당 멤버가 작성한 카테고리만 조회하도록 구현되어 있습니다.
- 하지만 공유용 뷰에서 카테고리를 조회할 때는 공유를 한 사람이 작성한 카테고리가 보여야 하므로 path parameter로 조회하고자 하는 유저의 id를 받도록 수정하였습니다.
- 이 과정에서 로그인 성공 시, 내려주는 response body에 memberId도 추가해서 내려줄 수 있도록 수정하였습니다.

    - 로그인 성공 시, memberId도 추가해서 내려주는 것 확인
    
        <img width="1073" alt="스크린샷 2023-11-09 오후 1 30 09" src="https://github.com/Katchup-dev/Katchup-server/assets/68415644/c7e47c70-0e41-414b-bd68-2ace1b844b10">

- 테스트 화면
<img width="941" alt="스크린샷 2023-11-09 오후 1 34 09" src="https://github.com/Katchup-dev/Katchup-server/assets/68415644/550981fc-4ee4-4004-ac36-deefaf9d5f77">

<img width="980" alt="image" src="https://github.com/Katchup-dev/Katchup-server/assets/68415644/a9c3d1e0-070f-4725-b909-6a33f4ed3e8e">




## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #202 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
